### PR TITLE
MOSAIC/BAG2 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Below is a list of the current tools already installed and ready to use (note th
 
 * [align](https://github.com/ALIGN-analoglayout/ALIGN-public) automatic layout generation for analog circuits (only on `amd64` and for `sky130` PDK)
 * [amaranth](https://github.com/amaranth-lang/amaranth) a Python-based HDL toolchain
+* [bag2](https://gitlab.com/mosaic_group/mosaic_BAG/opensource_db_template) Python-based analog layout generation and schematic transformation
 * [cocotb](https://github.com/cocotb/cocotb) simulation library for writing VHDL and Verilog test benches in Python
 * [covered](https://github.com/hpretl/verilog-covered) Verilog code coverage
 * [cvc](https://github.com/d-m-bailey/cvc) circuit validity checker (ERC)

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -71,8 +71,8 @@ ARG OPEN_PDKS_REPO_COMMIT="cd1748bb197f9b7af62a54507de6624e30363943"
 ARG OPEN_PDKS_NAME="open_pdks"
 COPY images/open_pdks/scripts/install_volare.sh install_volare.sh
 RUN bash install_volare.sh
-COPY images/open_pdks/scripts/install_ihp.sh install_ihp.sh
-RUN bash install_ihp.sh 
+# COPY images/open_pdks/scripts/install_ihp.sh install_ihp.sh
+# RUN bash install_ihp.sh 
 
 #######################################################################
 # Compile covered 
@@ -390,6 +390,17 @@ COPY images/rftoolkit/scripts/install.sh install.sh
 RUN bash install.sh
 
 #######################################################################
+# Compile BAG2
+#######################################################################
+FROM base as bag2
+# FIXME using a forked PDK since a few changes needed
+ARG BAG2_REPO_URL="https://gitlab.com/mosaic_group/mosaic_BAG/opensource_db_template.git"
+ARG BAG2_REPO_COMMIT="v1.2.1-iic-osic"
+ARG BAG2_NAME="bag2"
+COPY images/bag2/scripts/install.sh install.sh
+RUN bash install.sh
+
+#######################################################################
 # Final output container
 #######################################################################
 FROM basepkg as iic-osic-tools
@@ -452,6 +463,7 @@ COPY --from=yosys                        ${TOOLS}/              ${TOOLS}/
 COPY --from=ghdl-yosys-plugin            ${TOOLS}_add/          ${TOOLS}/
 COPY --from=align                        ${TOOLS}/              ${TOOLS}/
 COPY --from=align-pdk-sky130             ${TOOLS}/              ${TOOLS}/
+COPY --from=bag2                         ${TOOLS}/              ${TOOLS}/
 
 # Add design scripts and examples
 ADD images/align-utils ${TOOLS}/align-utils

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -71,8 +71,8 @@ ARG OPEN_PDKS_REPO_COMMIT="cd1748bb197f9b7af62a54507de6624e30363943"
 ARG OPEN_PDKS_NAME="open_pdks"
 COPY images/open_pdks/scripts/install_volare.sh install_volare.sh
 RUN bash install_volare.sh
-# COPY images/open_pdks/scripts/install_ihp.sh install_ihp.sh
-# RUN bash install_ihp.sh 
+COPY images/open_pdks/scripts/install_ihp.sh install_ihp.sh
+RUN bash install_ihp.sh 
 
 #######################################################################
 # Compile covered 

--- a/_build/images/bag2/scripts/install.sh
+++ b/_build/images/bag2/scripts/install.sh
@@ -21,5 +21,5 @@ export BAG_SRC_DIR="$BAG2_INSTALL_DIR"
 export BAG_GENERATOR_ROOT=/foss/designs/bag2
 export BAG_RUN_DIR=/foss/designs/bag2/BAG2_run_dir
 
-source $BAG_SRC_DIR/sourceme.sh
+source \$BAG_SRC_DIR/sourceme.sh
 EOF

--- a/_build/images/bag2/scripts/install.sh
+++ b/_build/images/bag2/scripts/install.sh
@@ -14,3 +14,12 @@ git checkout "$BAG2_REPO_COMMIT"
 
 ./init_submodules.sh
 ./pip3userinstall.sh
+
+# create a file to be sourced in the final .bashrc
+cat <<EOF > "$TOOLS/$BAG2_NAME/sourceme.sh"
+export BAG_SRC_DIR="$BAG2_INSTALL_DIR"
+export BAG_GENERATOR_ROOT=/foss/designs/bag2
+export BAG_RUN_DIR=/foss/designs/bag2/BAG2_run_dir
+
+source $BAG_SRC_DIR/sourceme.sh
+EOF

--- a/_build/images/bag2/scripts/install.sh
+++ b/_build/images/bag2/scripts/install.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+set -e
+
+# shorten real git commit hashes, but don't mess with tag or branch names
+REPO_COMMIT_SHORT=$(git rev-parse --quiet --short "$BAG2_REPO_COMMIT" || echo "$BAG2_REPO_COMMIT")
+
+BAG2_INSTALL_DIR="$TOOLS/$BAG2_NAME/$REPO_COMMIT_SHORT"
+
+mkdir -p "$TOOLS"
+git clone --filter=blob:none "$BAG2_REPO_URL" "$BAG2_INSTALL_DIR"
+cd "$BAG2_INSTALL_DIR" || exit 1
+git checkout "$BAG2_REPO_COMMIT"
+
+./init_submodules.sh
+./pip3userinstall.sh

--- a/_build/images/base/scripts/install.sh
+++ b/_build/images/base/scripts/install.sh
@@ -30,6 +30,19 @@ pip3 install --upgrade --no-cache-dir \
 	jupyter-collaboration \
 	jupyterlab-night
 
+# additional requirements for BAG2
+pip3 install --upgrade --no-cache-dir \
+  forallpeople \
+  GitPython \
+  h5py \
+  IPython \
+  jinja2 \
+  klayout \
+  openmdao \
+  rtree \
+  python-gitlab \
+  sphinx_rtd_theme \
+  zmq
 
 echo "[INFO] Install EDA packages via GEM"
 gem install \

--- a/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
+++ b/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
@@ -100,6 +100,8 @@ export PDKPATH=$PDK_ROOT/$PDK
 export STD_CELL_LIBRARY=sky130_fd_sc_hd
 export ALIGN_PDKPATH=${TOOLS}/align-pdk-sky130/SKY130_PDK
 
+# setup BAG2 environment
+source $TOOLS/bag2/sourceme.sh
 
 # FIXME: this gets rid of a few libGL errors
 # https://unix.stackexchange.com/questions/589236/libgl-error-no-matching-fbconfigs-or-visuals-found-glxgears-error-docker-cu

--- a/_build/tool_metadata_add.yml
+++ b/_build/tool_metadata_add.yml
@@ -1,3 +1,6 @@
+- name: bag2
+  repo: https://gitlab.com/mosaic_group/mosaic_BAG/opensource_db_template.git
+  commit: v1.2.1-iic-osic
 - name: covered
   repo: https://github.com/iic-jku/verilog-covered
   commit: 19d30fc942642b14dc24e95331cd4777c8dcbad9


### PR DESCRIPTION
## Motivation for this PR

This PR integrates the opensource version of the [MOSAIC/BAG2 flow](https://gitlab.com/mosaic_group/mosaic_BAG/opensource_db_template/-/blob/v1.2.1-iic-osic/README.md) (vulgo `opensource_db_template`) into `IIC-OSIC-TOOLS`.

The original (and still available) flow flavor (`virtuoso_template`) did require Cadence Virtuoso and related proprietary PDKs.
In contrast, `opensource_db_template` is now working fully open-source end-to-end, using `xschem`/`klayout` as DB, and is set up for `sky130A`, no longer depending on any proprietary software.

## Pending Dependencies

- klayout version `v0.28.13` is required, we'll wait for the `OpenLane` update (see https://github.com/iic-jku/IIC-OSIC-TOOLS/pull/20)

## Status (of OSS MOSAIC/BAG2)

**Working:**
- Layout and schematic generation 
- LVS
- DRC
- Common generator Tool `gen`
- Basic simulation and measurement support (*alpha*)

**TODO:**
- PEX/RCX is not yet implemented
- Simulation support is incomplete

## Usage Examples

### Example 1: "Hello World" 

After starting the container, the environment is already prepared
- Command line tool `gen` is already available (used to control/trigger BAG2 flow steps)
- `BAG2` is set up for use with PDK `sky130A`

The packages (generators, testbenches) are explicitly installed by the user, using `gen`.

```
gen --help   # see the available subcommands (similar to Git)

gen add --all-of mosaic        # install generator packages
gen add --all-of mosaic_tb   # install testbench packages

gen make amp_cs_gen    # run layout/schematic generation and LVS
gen drc amp_cs_gen       # run DRC

cd /foss/design/bag2
klayout amp_cs_generated_sky130_fd_pr.gds     # view the generated layout
xschem --rcfile xschem/xschemrc amp_cs_generated_sky130_fd_pr/amp_cs/amp_cs.s*     # view generated concrete schematic

gen sim amp_cs_gen                  # list available measurements
gen sim amp_cs_gen -m ac_tran   # run measurement and postprocessing using matplotlib
```

### Example 2: Two-stage opamp

```
gen add --all-of mosaic_opamp
gen make --gui always opamp_two_stage_fullchip_gen    # generate and open layout
```

## Attempt to be non-invasive

- As mentioned above, the environmental variables are set up
- But by default, `/foss/designs/bag2` will not be created
- Only if `gen` is invoked, `/foss/designs/bag2` and it's helper files will be created on-demand
