### PR TITLE
dependencies.sh: Download boost source archive from GitHub instead of JFrog

### DIFF
--- a/_build/images/base/scripts/dependencies.sh
+++ b/_build/images/base/scripts/dependencies.sh
@@ -194,13 +194,18 @@ apt-get -y remove libboost-all-dev
 BOOST_VER_MAJ=1
 BOOST_VER_MIN=82	
 BOOST_BUILD=0
-echo "[INFO] Installing BOOST version $BOOST_VER_MAJ.$BOOST_VER_MIN.$BOOST_BUILD.$BOOST_BUILD"
+BOOST_VERSION="$BOOST_VER_MAJ.$BOOST_VER_MIN.$BOOST_BUILD"
+echo "[INFO] Installing BOOST version $BOOST_VERSION"
 _install_boost () {
 	cd /tmp
 	# wget --no-verbose -O boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}.tar.gz https://sourceforge.net/projects/boost/files/boost/$BOOST_VER_MAJ.$BOOST_VER_MIN.$BOOST_BUILD/boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}.tar.gz/download
-	wget --no-verbose https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VER_MAJ.$BOOST_VER_MIN.$BOOST_BUILD/source/boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}.tar.gz
-	tar -xf boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}.tar.gz
-	cd boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}
+
+	# as of 2024-01-08, this redirects us to a web page
+	# wget --no-verbose https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VER_MAJ.$BOOST_VER_MIN.$BOOST_BUILD/source/boost_${BOOST_VER_MAJ}_${BOOST_VER_MIN}_${BOOST_BUILD}.tar.gz
+
+	wget --no-verbose https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz
+	tar -xf boost-${BOOST_VERSION}.tar.gz
+	cd boost-${BOOST_VERSION}
 	./bootstrap.sh
 	./b2 install
 }


### PR DESCRIPTION
Fixes #29 