### PR TITLE
Add ICPS PDK

### DIFF
--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -75,6 +75,17 @@ COPY images/open_pdks/scripts/install_ihp.sh install_ihp.sh
 RUN bash install_ihp.sh 
 
 #######################################################################
+# Install ICPS PDK
+#######################################################################
+FROM base as icps
+ARG ICPS_REPO_URL="https://github.com/mineda-support/ICPS2023_5.git"
+ARG ICPS_REPO_COMMIT="46777431c951df99138d292db8fa5be1c74762c0"
+ARG ANAGIXLOADER_REPO_URL="https://github.com/mineda-support/AnagixLoader.git"
+ARG ANAGIXLOADER_REPO_COMMIT="6176890a4311afd6583cb253d6b63e1b33f349a2"
+COPY images/open_pdks/scripts/install_icps.sh install_icps.sh
+RUN bash install_icps.sh
+
+#######################################################################
 # Compile covered 
 #######################################################################
 FROM base as covered
@@ -416,6 +427,8 @@ ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
 # Copy all layers into the final container
 COPY --from=open_pdks                    ${PDK_ROOT}/           ${PDK_ROOT}/
+COPY --from=icps                         ${PDK_ROOT}/           ${PDK_ROOT}/
+COPY --from=icps                         /headless/             /headless/
 COPY --from=covered                      ${TOOLS}/              ${TOOLS}/
 COPY --from=cvc_rv                       ${TOOLS}/              ${TOOLS}/
 COPY --from=fault                        ${TOOLS}/              ${TOOLS}/

--- a/_build/images/open_pdks/scripts/install_icps.sh
+++ b/_build/images/open_pdks/scripts/install_icps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d "$PDK_ROOT" ]; then
+    mkdir -p "$PDK_ROOT"
+fi
+
+####################
+# INSTALL ICPS PDK
+####################
+
+echo "[INFO] Installing ICPS PDK."
+
+git clone --filter=blob:none "${ANAGIXLOADER_REPO_URL}" $PDK_ROOT/icps/AnagixLoader
+cd $PDK_ROOT/icps/AnagixLoader
+git checkout "${ANAGIXLOADER_REPO_COMMIT}"
+
+git clone --filter=blob:none "${ICPS_REPO_URL}" $PDK_ROOT/icps/ICPS2023_5
+cd $PDK_ROOT/icps/ICPS2023_5
+git checkout "${ICPS_REPO_COMMIT}"
+
+# Create symlink to KLayout salt directory
+mkdir -p /headless/.klayout/salt/
+ln -s $PDK_ROOT/icps/AnagixLoader /headless/.klayout/salt/AnagixLoader
+ln -s $PDK_ROOT/icps/ICPS2023_5 /headless/.klayout/salt/ICPS2023_5


### PR DESCRIPTION
This is just a *very* preliminary support for the ICPS PDK (https://github.com/mineda-support/ICPS2023_5).

Unfortunately, the folder structure is completely different from the other open pdks.
So far, this PR clones the two repos to `/foss/pdks/icps/AnagixLoader/` and `/foss/pdks/icps/ICPS2023_5/` and creates symlinks to `/headless/.klayout/salt/`.

I would have expected KLayout to be able to load the plugins, but it seems like KLayout expects the plugins under: `/foss/pdks/sky130A/libs.tech/klayout/salt/`. Maybe someone could clarify how this works ^^

Next, I would like to create a `xschemrc` for the ICPS PDK that loads the symbol library and opens an example design.
How does it work that depending on the `$PDK` env variable a different xschemrc is loaded?

Comments and suggestions are very welcome!