### PR TITLE
Add smoke tests for the pulp-tools

### DIFF
--- a/_tests/08/Bender.yml
+++ b/_tests/08/Bender.yml
@@ -1,0 +1,22 @@
+# Copyright 2024 ETH Zurich and University of Bologna
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+package:
+  name: smoke_test
+  authors:
+    - "Philippe Sauter <phsauter@iis.ee.ethz.ch>"
+
+dependencies:
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", rev: 10dac0ff3387e14b1129be33cad1e9a7d71aed7f }
+
+sources:
+  # Level 0
+  - target: not(test_target)
+    files:
+      - error.sv
+
+    # RTL
+  - target: test_target
+    files:
+      - top.sv

--- a/_tests/08/error.sv
+++ b/_tests/08/error.sv
@@ -1,0 +1,12 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+module top (
+    input  logic clk_i,
+);
+
+endmodule

--- a/_tests/08/test_pulp_flow.sh
+++ b/_tests/08/test_pulp_flow.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Harald Pretl
+# Johannes Kepler University, Institute for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smoke test for the following tools:
+# - bender: https://github.com/pulp-platform/bender
+# - morty:  https://github.com/pulp-platform/morty
+# - svase:  https://github.com/pulp-platform/svase
+# - sv2v:   https://github.com/zachjs/sv2v
+
+# test if a command finishes successfully
+test() {
+    local cmd="$1"
+    echo "Running: $cmd"
+    eval "$cmd" &>> $LOG
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] '$cmd' failed" >> $LOG
+    fi
+    echo -e "\n\n\n" >> $LOG
+}
+
+# test if a command fails
+test_fail() {
+    local cmd="$1"
+    echo "Running: $cmd"
+    eval "$cmd" &>> $LOG
+    if [ $? -eq 0 ]; then
+        echo "[ERROR] '$cmd' was expected to fail but succeeded" >> $LOG
+    else
+        echo "[INFO] '$cmd' failed as expected" >> $LOG
+    fi
+    echo -e "\n\n\n" >> $LOG
+}
+
+TMP=/tmp/test_08
+LOG=$TMP/tools.log
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+
+if [ -d $TMP ]; then
+    rm -rf $TMP/*
+else 
+    mkdir $TMP
+fi
+
+cp $DIR/Bender.yml $TMP/
+cp $DIR/*.sv       $TMP/
+cd $TMP/
+
+echo "Testing bender..."
+{
+    test "bender update"
+    test "bender checkout"
+    test "bender sources -f > error.json"
+    test "bender sources -f -t test_target > top.json"
+} &> $LOG
+
+echo "Testing morty..."
+{
+    test_fail "morty -q -f error.json -o error_morty.sv"
+    test "morty -q -f top.json -o top_morty.sv"
+    test "morty -q -f top.json -D ERROR -o error_morty.sv"
+} &> $LOG
+
+echo "Testing svase..."
+{
+    test_fail "svase top error_svase.sv error_morty.sv"
+    test "svase top top_svase.sv top_morty.sv"
+} &> $LOG
+
+echo "Testing sv2v..."
+{
+    test "sv2v --write top_sv2v.v top_svase.sv"
+    test "yosys -Q -q -p \"read_verilog top_sv2v.v; synth;\""
+} &> $LOG
+
+
+if grep -q "\[ERROR\]" $LOG; then
+    echo "PULP-flow smoke test ERRORS. Check log at $LOG"
+    exit 1
+else
+    echo "PULP-flow smoke test completed successfully."
+    exit 0
+fi

--- a/_tests/08/top.sv
+++ b/_tests/08/top.sv
@@ -1,0 +1,65 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`ifdef ERROR
+`timescale 1ns / 1ps
+`endif
+
+module top (
+    input  logic       clk_i,
+    input  logic       rst_ni,
+
+    input  logic       clear_i,
+    input  logic       en_i,
+    input  logic       load_i,
+    input  logic       down_i,
+    input  logic [7:0] delta_i,
+    input  logic [7:0] d_i,
+    output logic [7:0] q_o,
+    output logic [7:0] max_o,
+
+    input  logic       pop_i,
+    output logic       full_o
+);
+    logic [7:0] data;
+
+    max_counter #(
+        .WIDTH(8)
+    ) i_max (
+        .clk_i,
+        .rst_ni,
+        .clear_i, 
+        .clear_max_i ( 1'b0 ),
+        .en_i,
+        .load_i,
+        .down_i,
+        .delta_i,
+        .d_i,
+        .q_o ( data ),
+        .max_o,
+        .overflow_o     ( ),
+        .overflow_max_o ( )
+    );
+
+    fifo_v3 #(
+        .FALL_THROUGH ( 1'b0 ),
+        .DATA_WIDTH   ( 8 ),
+        .DEPTH        ( 4 )
+    ) i_fifo (
+        .clk_i,
+        .rst_ni,
+        .flush_i    ( clear_i ),
+        .testmode_i (  1'b0   ),
+        .full_o,
+        .empty_o ( ),
+        .usage_o ( ),
+        .data_i  ( data ),
+        .push_i  ( en_i ),
+        .data_o  ( q_o ),
+        .pop_i
+    );
+endmodule

--- a/_tests/09/crt0.S
+++ b/_tests/09/crt0.S
@@ -1,0 +1,39 @@
+# Copyright (c) 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# from: https://github.com/pulp-platform/croc/blob/main/sw/crt0.S
+#
+# Authors:
+# - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+.globl _start
+.section .text._start
+_start:
+  # Global pointer
+  .option push
+  .option norelax
+  la      x3, __global_pointer$
+  .option pop
+  # Stack pointer
+  la      x2, __stack_pointer$
+  # Reset vector
+  li      x1, 0
+  li      x4, 0
+  li      x5, 0
+  li      x6, 0
+  li      x7, 0
+  li      x8, 0
+  li      x9, 0
+  li      x10, 0
+  li      x11, 0
+  li      x12, 0
+  li      x13, 0
+  li      x14, 0
+  li      x15, 0
+  call main
+_eoc:
+  la      t0, status
+  sw      a0, 0(t0)
+  wfi

--- a/_tests/09/link.ld
+++ b/_tests/09/link.ld
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# from: https://github.com/pulp-platform/croc/blob/main/sw/link.ld
+#
+# Authors:
+# - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+OUTPUT_ARCH("riscv")
+ENTRY(_start)
+
+MEMORY 
+{
+   SRAM (rwxail) : ORIGIN = 0x10000000, LENGTH = 2K
+}
+
+SECTIONS
+{
+  /DISCARD/ : { *(.riscv.attributes) *(.comment) }
+
+  .text._start 0x10000080 : { *(.text._start) } >SRAM
+  .text : { *(.text) *(.text.*) } >SRAM
+  .misc : { *(.sdata) *(.*) } >SRAM
+  
+  __global_pointer$ = ADDR(.misc); 
+  __stack_pointer$  = ORIGIN(SRAM) + LENGTH(SRAM) -4;
+
+  status  = 0x03000008;
+}

--- a/_tests/09/main.c
+++ b/_tests/09/main.c
@@ -1,0 +1,6 @@
+void main() {
+    int a = 5;
+    int b = 10;
+    int c = 8;
+    return (a*b)-c;
+}

--- a/_tests/09/test_riscv64-unknown-elf_tools.sh
+++ b/_tests/09/test_riscv64-unknown-elf_tools.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Harald Pretl
+# Johannes Kepler University, Institute for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smoke test for the riscv64-unknown-elf tools
+
+# test if a command finishes successfully
+test() {
+    local cmd="$1"
+    echo "Running: $cmd"
+    eval "$cmd" &>> $LOG
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] '$cmd' failed" >> $LOG
+    fi
+    echo -e "\n\n\n" >> $LOG
+}
+
+TMP=/tmp/test_09
+LOG=$TMP/tools.log
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+
+if [ -d $TMP ]; then
+    rm -rf $TMP/*
+else 
+    mkdir $TMP
+fi
+
+cp $DIR/crt0.S     $TMP/
+cp $DIR/link.ld    $TMP/
+cp $DIR/main.c     $TMP/
+cd $TMP/
+
+RISCV_PREFIX=riscv64-unknown-elf
+RISCV_CC=$RISCV_PREFIX-gcc
+RISCV_lD=$RISCV_PREFIX-ld
+RISCV_FLAGS="-march=rv32i -mabi=ilp32  -mcmodel=medany -static -ffast-math"
+
+echo "Testing riscv64-unknown-elf tools..."
+{
+    test "$RISCV_CC $RISCV_FLAGS -c main.c -o main.o"
+    test "$RISCV_CC $RISCV_FLAGS -c crt0.S -o crt0.o"
+    test "$RISCV_CC $RISCV_FLAGS -nostartfiles -lm -lgcc -Tlink.ld -o main.elf main.o crt0.o"
+} &> $LOG
+
+if grep -q "\[ERROR\]" $LOG; then
+    echo "riscv64-unknown-elf smoke test ERRORS. Check log at $LOG"
+    exit 1
+else
+    echo "riscv64-unknown-elf smoke test completed successfully."
+    exit 0
+fi


### PR DESCRIPTION
Adds simple tests for the following tools:
-  bender
- morty
- svase
- sv2v
- read-in and synth in yosys (to test entire flow)
- riscv64-unknown-elff-gcc compiler

runtime: <1min