### PR TITLE
Add support for devcontainers

### DIFF
--- a/.github/workflows/devcontainer-docker.yaml
+++ b/.github/workflows/devcontainer-docker.yaml
@@ -1,0 +1,59 @@
+name: "Build and publish devcontainer"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Container version'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  # This does not work as the lowercase conversion does not work then,
+  # and we don't want the name of the docker container to clash
+  #IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository_owner }}/iic-osic-tools-devcontainer
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+    
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}    
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: "./_build/devcontainer/image/"
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}"
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ github.event.inputs.version }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/devcontainer-template.yaml
+++ b/.github/workflows/devcontainer-template.yaml
@@ -1,0 +1,24 @@
+name: "Release devcontainer template"
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-templates:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Publish Templates"
+        uses: devcontainers/action@v1
+        with:
+          publish-templates: "true"
+          base-path-to-templates: "./_build/devcontainer/iic-osic-tools"
+          generate-docs: "true"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This environment is based on the [efabless.com FOSS-ASIC-TOOLS](https://github.c
     - [4.4 Overwriting Shell Variables](#44-overwriting-shell-variables)
       - [4.4.1 For the Linux/macOS Bash Scripts](#441-for-the-linuxmacos-bash-scripts)
       - [4.4.2 For the Windows Batch Scripts](#442-for-the-windows-batch-scripts)
+    - [4.5 Using as devcontainer](#45-using-as-devcontainer)
+      - [4.5.1 Add it to project](#451-add-it-to-project)
   - [5. Support with Issues/Problems/Bugs](#5-support-with-issuesproblemsbugs)
 
 ## 1. How to Use These Open-Source (and Free) IC Design Tools
@@ -35,6 +37,7 @@ It supports two *modes of operation*:
 
 1. Using a complete desktop environment (XFCE) in `Xvnc` (a VNC server), either directly accessing it with a VNC client of your choice or the integrated [noVNC](https://novnc.com) server that runs in your browser.
 2. Using a local X11 server and directly showing the application windows on your desktop.
+3. Using it as a development container in Visual Studio Code (or other IDEs)
 
 ### 1.1 Step 1: Clone/download this GitHub repository onto your computer
 
@@ -283,6 +286,24 @@ SET DESIGNS=\my\design\directory
 SET DOCKER_USERNAME=another_user
 .\start_x.bat
 ```
+### 4.5 Using as devcontainer
+
+This is a new usage mode, that might not fit your needs. [Devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) are a great way to provide a working build environment along your own project. It is supported by the [devcontainer](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in Visual Studio Code.
+
+#### 4.5.1 Add it to project
+
+Option 1: In Visual Studio, click the remote window icon on the left and then "Reopen in Container", "Add configuration to workspace". Enter "ghcr.io/iic-jku/iic-osic-tools/devcontainer" as template, choose the version of the container and add more features (probably not needed). It will then restart the IDE, download the image and start a terminal and mount the work folder into the image.
+
+Option 2: Alternatively you can directly just create the configuration file `.devcontainer/devcontainer.json`:
+
+```json
+{
+	"name": "IIC-OSIC-TOOLS",
+	"image": "ghcr.io/iic-jku/iic-osic-tools-devcontainer:2024.09"
+}
+```
+
+Either way, the great thing is that you can now commit the file to repository and all developers will be asked if they want to reopen their development in this container, all they need is Docker and VSCode.
 
 ## 5. Support with Issues/Problems/Bugs
 

--- a/_build/devcontainer/README.md
+++ b/_build/devcontainer/README.md
@@ -1,0 +1,18 @@
+# Devcontainer image and template
+
+In the subfolders you can find support for the
+[devcontainers](https://containers.dev/) infrastructure:
+
+- The Docker image variant prepared for devcontainers
+- The template for Visual Studio code to add it easily
+
+## Docker Image
+
+The docker image takes the IIC-OSIC-TOOLS Docker image as base and performs a
+very minor operation: Properly creating the user directly. Later we might need
+to add more devcontainer-specific support once we run into issues, or might
+deprecate the image in case that the base image works directly.
+
+## Template
+
+This is the template to be released as a GitHub Package.

--- a/_build/devcontainer/iic-osic-tools/.devcontainer/devcontainer.json
+++ b/_build/devcontainer/iic-osic-tools/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "IIC-OSIC-TOOLS",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "ghcr.io/wallento/iic-osic-tools-devcontainer:${templateOption:version}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties. Here are some suggested extensions.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"mshr-h.veriloghdl",
+				"surfer-project.surfer"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/_build/devcontainer/iic-osic-tools/.devcontainer/devcontainer.json
+++ b/_build/devcontainer/iic-osic-tools/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "IIC-OSIC-TOOLS",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "ghcr.io/wallento/iic-osic-tools-devcontainer:${templateOption:version}",
+	"image": "ghcr.io/iic-jku/iic-osic-tools-devcontainer:${templateOption:version}",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/_build/devcontainer/iic-osic-tools/devcontainer-template.json
+++ b/_build/devcontainer/iic-osic-tools/devcontainer-template.json
@@ -1,0 +1,19 @@
+{
+    "id": "devcontainer",
+    "version": "1.0.0",
+    "name": "IIC-OSIC-TOOLS",
+    "description": "IIC-OSIC-TOOLS is an all-in-one Docker image for SKY130/GF180/IHP130-based analog and digital chip design. AMD64 and ARM64 are natively supported.",
+    "licenseURL": "https://github.com/iic-jku/IIC-OSIC-TOOLS/blob/main/LICENSE",
+    "platforms": [
+        "ARM64", "AMD64"
+    ],
+    "options": {
+        "version": {
+          "type": "string",
+          "description": "Version",
+          "proposals": ["2024.09", "2024.08"],
+          "default": "2024.09"
+        }
+    }
+
+}

--- a/_build/devcontainer/image/Dockerfile
+++ b/_build/devcontainer/image/Dockerfile
@@ -1,0 +1,5 @@
+ARG VERSION="latest"
+FROM hpretl/iic-osic-tools:${VERSION}
+USER root
+RUN useradd -m -s /bin/bash -G sudo designer
+USER designer


### PR DESCRIPTION
Devcontainers make it very easy for project to distribute the working development environment to their developers using VSCode.

This adds support for devcontainer, including the Github action.

The workflow is as following:

- With every new version of the container, go to the GitHub actions, pick the "Build and publish devcontainer", and trigger the workflow action with the new version as parameter

- Add the version to the devcontainer template, so that users can pick it, also update the version of template so it gets published (just increment the patch version), then trigger the workflow "Release devcontainer template"