### PR TITLE
Improve start scripts banner

### DIFF
--- a/start_vnc.bat
+++ b/start_vnc.bat
@@ -1,21 +1,22 @@
-REM ========================================================================
-REM SPDX-FileCopyrightText: 2022-2023 Harald Pretl and Georg Zachl
-REM Johannes Kepler University, Institute for Integrated Circuits
-REM
-REM Licensed under the Apache License, Version 2.0 (the "License");
-REM you may not use this file except in compliance with the License.
-REM You may obtain a copy of the License at
-REM
-REM     http://www.apache.org/licenses/LICENSE-2.0
-REM
-REM Unless required by applicable law or agreed to in writing, software
-REM distributed under the License is distributed on an "AS IS" BASIS,
-REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-REM See the License for the specific language governing permissions and
-REM limitations under the License.
-REM SPDX-License-Identifier: Apache-2.0
-REM ========================================================================
 @echo off
+
+Echo ========================================================================
+Echo SPDX-FileCopyrightText: 2022-2023 Harald Pretl and Georg Zachl
+Echo Johannes Kepler University, Institute for Integrated Circuits
+Echo.
+Echo Licensed under the Apache License, Version 2.0 (the "License");
+Echo you may not use this file except in compliance with the License.
+Echo You may obtain a copy of the License at
+Echo.
+Echo     http://www.apache.org/licenses/LICENSE-2.0
+Echo.
+Echo Unless required by applicable law or agreed to in writing, software
+Echo distributed under the License is distributed on an "AS IS" BASIS,
+Echo WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Echo See the License for the specific language governing permissions and
+Echo limitations under the License.
+Echo SPDX-License-Identifier: Apache-2.0
+Echo ========================================================================
 
 SETLOCAL
 

--- a/start_x.bat
+++ b/start_x.bat
@@ -1,21 +1,22 @@
-REM ========================================================================
-REM SPDX-FileCopyrightText: 2022-2023 Harald Pretl and Georg Zachl
-REM Johannes Kepler University, Institute for Integrated Circuits
-REM
-REM Licensed under the Apache License, Version 2.0 (the "License");
-REM you may not use this file except in compliance with the License.
-REM You may obtain a copy of the License at
-REM
-REM     http://www.apache.org/licenses/LICENSE-2.0
-REM
-REM Unless required by applicable law or agreed to in writing, software
-REM distributed under the License is distributed on an "AS IS" BASIS,
-REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-REM See the License for the specific language governing permissions and
-REM limitations under the License.
-REM SPDX-License-Identifier: Apache-2.0
-REM ========================================================================
 @echo off
+
+Echo ========================================================================
+Echo SPDX-FileCopyrightText: 2022-2023 Harald Pretl and Georg Zachl
+Echo Johannes Kepler University, Institute for Integrated Circuits
+Echo.
+Echo Licensed under the Apache License, Version 2.0 (the "License");
+Echo you may not use this file except in compliance with the License.
+Echo You may obtain a copy of the License at
+Echo.
+Echo     http://www.apache.org/licenses/LICENSE-2.0
+Echo.
+Echo Unless required by applicable law or agreed to in writing, software
+Echo distributed under the License is distributed on an "AS IS" BASIS,
+Echo WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Echo See the License for the specific language governing permissions and
+Echo limitations under the License.
+Echo SPDX-License-Identifier: Apache-2.0
+Echo ========================================================================
 
 SETLOCAL
 


### PR DESCRIPTION
Hey, I noticed there's a bad usage of REM on the "start_vnc.bat" and "start_x.bat". It's a minor issue, but I switched it to Echo to improve readability.
![Before](https://github.com/user-attachments/assets/1d542838-c9ad-4160-a2d1-531bf9e35154)
![After](https://github.com/user-attachments/assets/837d2798-4007-4ef5-9167-734085034cd6)
