### PR TITLE
Add Surfer Waveform Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Below is a list of the current tools already installed and ready to use (note th
 * [spike](https://github.com/riscv-software-src/riscv-isa-sim) Spike RISC-V ISA simulator
 * [spyci](https://github.com/gmagno/spyci) analyze/plot `ngspice`/`xyce` output data with Python
 * [surelog](https://github.com/chipsalliance/Surelog) SystemVerilog parser, elaborator, and UHDM compiler
+* [surfer](https://gitlab.com/surfer-project/surfer) waveform viewer with snappy usable interface and extensibility
 * [vlog2verilog](https://github.com/RTimothyEdwards/qflow) Verilog file conversion
 * [volare](https://github.com/efabless/volare) version manager (and builder) for open-source PDKs
 * [risc-v toolchain](https://github.com/riscv/riscv-gnu-toolchain) GNU compiler toolchain for RISC-V cores

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -264,6 +264,15 @@ RUN --mount=type=bind,source=images/surelog,target=/images/surelog \
     bash /images/surelog/scripts/install.sh
 
 #######################################################################
+# Compile surfer
+#######################################################################
+FROM rust:1.82 AS surfer
+ARG SURFER_REPO_URL="https://gitlab.com/surfer-project/surfer"
+ARG SURFER_REPO_COMMIT="v0.3.0"
+RUN --mount=type=bind,source=images/surfer,target=/images/surfer \
+    bash /images/surfer/scripts/install.sh
+
+#######################################################################
 # Compile qflow helper files
 #######################################################################
 FROM base AS qflow
@@ -476,6 +485,7 @@ COPY --from=riscv-pk                     ${TOOLS}/              ${TOOLS}/
 COPY --from=slang                        ${TOOLS}/              ${TOOLS}/
 COPY --from=spike                        ${TOOLS}/              ${TOOLS}/
 COPY --from=surelog                      ${TOOLS}/              ${TOOLS}/
+COPY --from=surfer                       ${TOOLS}/              ${TOOLS}/
 COPY --from=verilator                    ${TOOLS}/              ${TOOLS}/
 COPY --from=xcircuit                     ${TOOLS}/              ${TOOLS}/
 COPY --from=xschem                       ${TOOLS}/              ${TOOLS}/

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -266,9 +266,10 @@ RUN --mount=type=bind,source=images/surelog,target=/images/surelog \
 #######################################################################
 # Compile surfer
 #######################################################################
-FROM rust:1.82 AS surfer
+FROM base AS surfer
 ARG SURFER_REPO_URL="https://gitlab.com/surfer-project/surfer"
 ARG SURFER_REPO_COMMIT="v0.3.0"
+ARG SURFER_NAME="surfer"
 RUN --mount=type=bind,source=images/surfer,target=/images/surfer \
     bash /images/surfer/scripts/install.sh
 

--- a/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
+++ b/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
@@ -150,6 +150,7 @@ alias k='klayout -nn $PDKPATH/libs.tech/klayout/tech/$PDK.lyt'
 alias ke='klayout -e -nn $PDKPATH/libs.tech/klayout/tech/$PDK.lyt'
 
 alias openlane='openlane --manual-pdk'
+alias surfer="LIBGL_ALWAYS_INDIRECT=0 surfer"
 
 #FIXME Show hint that OpenLane(1) has been removed
 alias flow.tcl='printf "[INFO] OpenLane(1) has been depreciated.\n[INFO] Please use OpenLane2 (start with <openlane>).\n"'

--- a/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
+++ b/_build/images/iic-osic-tools/skel/dockerstartup/scripts/env.sh
@@ -78,6 +78,7 @@ if [ -z ${FOSS_INIT_DONE+x} ]; then
     _path_add_tool_bin      "qucs-s"
     _path_add_tool_custom   "rftoolkit/bin"
     _path_add_tool_bin      "slang"
+    _path_add_tool_bin      "surfer"
     _path_add_tool_bin      "verilator"
     _path_add_tool_bin      "xschem"
     _path_add_tool_bin      "xyce"

--- a/_build/images/surfer/install.sh
+++ b/_build/images/surfer/install.sh
@@ -1,0 +1,1 @@
+cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} --root ${TOOLS} surfer

--- a/_build/images/surfer/install.sh
+++ b/_build/images/surfer/install.sh
@@ -1,1 +1,0 @@
-cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} --root ${TOOLS} surfer

--- a/_build/images/surfer/scripts/install.sh
+++ b/_build/images/surfer/scripts/install.sh
@@ -1,0 +1,1 @@
+cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} surfer --root "${TOOLS}"

--- a/_build/images/surfer/scripts/install.sh
+++ b/_build/images/surfer/scripts/install.sh
@@ -1,2 +1,16 @@
+#!/bin/bash
 set -e
-cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} surfer --root "${TOOLS}"
+cd /tmp || exit 1
+
+# install rust toolchain via rustup (surfer needs newer rust compiler than available in Ubuntu 24.04 LTS)
+export RUSTUP_HOME=/tmp/rustup
+export CARGO_HOME=/tmp/cargo
+export PATH=$CARGO_HOME/bin:$PATH
+export RUSTUP_INIT_SKIP_PATH_CHECK=yes
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+chmod +x rustup-init.sh
+./rustup-init.sh --no-modify-path -y
+
+# install surfer
+cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} surfer --root "${TOOLS}/${SURFER_NAME}"

--- a/_build/images/surfer/scripts/install.sh
+++ b/_build/images/surfer/scripts/install.sh
@@ -1,1 +1,2 @@
+set -e
 cargo install --git ${SURFER_REPO_URL} --tag ${SURFER_REPO_COMMIT} surfer --root "${TOOLS}"

--- a/_build/tool_metadata.yml
+++ b/_build/tool_metadata.yml
@@ -82,6 +82,9 @@
 - name: surelog
   repo: https://github.com/chipsalliance/Surelog.git
   commit: "v1.84"
+- name: surfer
+  repo: https://gitlab.com/surfer-project/surfer
+  commit: "v0.3.0"
 - name: trilinos
   repo: https://github.com/trilinos/Trilinos.git
   commit: "trilinos-release-12-12-1"


### PR DESCRIPTION
Adds install scripts and aliases to run [Surfer](https://surfer-project.org/), an open source waveform viewer that is a nice alternative to Gtkwave.



