### PR TITLE
Add rggen-veryl

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Below is a list of the current tools/PDKs already installed and ready to use:
 - [pyverilog](https://github.com/PyHDI/Pyverilog) Python toolkit for Verilog
 - [qflow](https://github.com/RTimothyEdwards/qflow) collection of useful conversion tools
 - [qucs-s](https://github.com/ra3xdh/qucs_s) simulation environment with RF emphasis
-- [rggen](https://github.com/rggen/rggen) code generation tool for configuration and status registers
+- [rggen](https://github.com/rggen/rggen) Code generation tool for control and status registers
 - [risc-v toolchain](https://github.com/riscv/riscv-gnu-toolchain) GNU compiler toolchain for RISC-V cores, incl. [Spike](https://github.com/riscv-software-src/riscv-isa-sim) RISC-V ISA simulator
 - [riscv-pk](https://github.com/riscv-software-src/riscv-pk) RISC-V proxy kernel and bootloader
 - [schemdraw](https://github.com/cdelker/schemdraw) Python package for drawing electrical schematics

--- a/_build/images/base/scripts/90_basepkg_install.sh
+++ b/_build/images/base/scripts/90_basepkg_install.sh
@@ -49,4 +49,5 @@ echo "[INFO] Install EDA packages via GEM"
 gem install \
 	rggen \
 	rggen-verilog \
-	rggen-vhdl
+	rggen-vhdl \
+	rggen-veryl


### PR DESCRIPTION
refs: https://github.com/iic-jku/IIC-OSIC-TOOLS/issues/139#issuecomment-2969668120

RgGen also supports generating CSR modules written in Veryl.
This PR is to add the `rggen-veryl` plugin to the image.