### PR TITLE
Updated sak-*.sh files for IHP PDK

### DIFF
--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-drc.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-drc.sh
@@ -61,6 +61,8 @@ if echo "$PDK" | grep -q -i "sky130"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] sky130 PDK selected."
 elif echo "$PDK" | grep -q -i "gf180mcu"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] gf180mcu PDK selected."
+elif echo "$PDK" | grep -q -i "ihp-sg13g2"; then
+	[ $DEBUG -eq 1 ] && echo "[INFO] ihp-sg13g2 PDK selected"
 else
 	echo "[ERROR] The PDK $PDK is not yet supported!"
 	exit $ERR_PDK_NOT_SUPPORTED
@@ -301,7 +303,12 @@ if [ $RUN_KLAYOUT -eq 1 ]; then
 	if echo "$PDK" | grep -q -i "gf180mcu"; then
 		echo "[ERROR] KLayout DRC for $PDK not yet supported!"
 		exit $ERR_PDK_NOT_SUPPORTED
-	fi	
+	fi
+
+  if echo "$PDK" | grep -q -i "ihp-sg13g2"; then
+		echo "[ERROR] KLayout DRC for $PDK not yet supported!"
+		exit $ERR_PDK_NOT_SUPPORTED
+	fi
 fi
 
 # wait for all runs to finish

--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-lvs.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-lvs.sh
@@ -79,6 +79,8 @@ if echo "$PDK" | grep -q -i "sky130"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] sky130 PDK selected."
 elif echo "$PDK" | grep -q -i "gf180mcu"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] gf180mcu PDK selected."
+elif echo "$PDK" | grep -q -i "ihp-sg13g2"; then
+	[ $DEBUG -eq 1 ] && echo "[INFO] ihp-sg13g2 PDK selected"
 else
 	echo "[ERROR] The PDK $PDK is not yet supported!"
 	exit $ERR_PDK_NOT_SUPPORTED

--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
@@ -120,6 +120,8 @@ if echo "$PDK" | grep -q -i "sky130"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] sky130 PDK selected"
 elif echo "$PDK" | grep -q -i "gf180mcu"; then
 	[ $DEBUG -eq 1 ] && echo "[INFO] gf180mcu PDK selected"
+elif echo "$PDK" | grep -q -i "ihp-sg13g2"; then
+	[ $DEBUG -eq 1 ] && echo "[INFO] ihp-sg13g2 PDK selected"
 else
 	echo "[ERROR] The PDK $PDK is not yet supported!"
 	exit $ERR_PDK_NOT_SUPPORTED


### PR DESCRIPTION
In the YouTube video (https://www.youtube.com/watch?v=Z9TWs1sGmTk&t=271s&ab_channel=MarcinMa%C5%9Blanka) it was pointed out that the sak-*.sh files do not support IHP PDK.

What I did:
- I added an if-branch for ihp-sg13g2 PDK to all three files.
- Now, PEX and LVS also work for the IHP PDK.
- DRC for the IHP PDK only works for Magic (-m).
- KLayout DRC support is still missing in sak-drc.sh for gf180mcu & ihp-sg13g2 (-k, -b). Maybe this is something @martinjankoehler can add? For sky130a, it is implemented and hopefully is easily portable to gf180mcu & ihp-sg13g2.

@martinjankoehler, BTW, if your KLayout PEX works, please update sak-pex.sh with your KLayout PEX and add an input parameter to switch between Magic PEX and KLayout PEX (or both), as shown in sak-drc.sh.

FYI: @MrHighVoltage, @p-fath, @Scafir