### PR TITLE
Temporary solution of IHP PDK fixes deleted, as IHP PDK is now cloned from iic-jku

### DIFF
--- a/_build/images/open_pdks/scripts/install_ihp.sh
+++ b/_build/images/open_pdks/scripts/install_ihp.sh
@@ -56,18 +56,3 @@ rm -rf "$PDK_ROOT/$PDK/libs.doc/meas"
 #FIXME gzip Liberty (.lib) files
 #FIXME cd "$PDK_ROOT/$PDK/libs.ref"
 #FIXME find . -name "*.lib" -exec gzip {} \;
-
-# replace klayout pcells of ihpsg13g2 pdk to get an extra option for creating a guard ring and a via_stack
-# FIXME this is only a temporary solution until the PR in the IHP-Open-PDK repo is merged
-git clone -b dev https://github.com/iic-jku/IHP-Open-PDK.git /tmp/IHP-Open-PDK
-
-rm -rf $PDK_ROOT/$PDK/libs.tech/klayout/python/sg13g2_pycell_lib
-cp -rf /tmp/IHP-Open-PDK/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib $PDK_ROOT/$PDK/libs.tech/klayout/python/
-cp -r /tmp/IHP-Open-PDK/ihp-sg13g2/libs.tech/klayout/python/sg13g2_native_pcell_lib/ $PDK_ROOT/$PDK/libs.tech/klayout/python
-rm -rf $PDK_ROOT/$PDK/libs.tech/klayout/tech/pymacros/autorun.lym
-cp -r /tmp/IHP-Open-PDK/ihp-sg13g2/libs.tech/klayout/tech/pymacros/autorun.lym $PDK_ROOT/$PDK/libs.tech/klayout/tech/pymacros
-
-cp -rf /tmp/IHP-Open-PDK/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ptap1_ring.sym $PDK_ROOT/$PDK/libs.tech/xschem/sg13g2_pr/
-cp -rf /tmp/IHP-Open-PDK/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ntap1_ring.sym $PDK_ROOT/$PDK/libs.tech/xschem/sg13g2_pr/
-
-rm -rf /tmp/IHP-Open-PDK


### PR DESCRIPTION
Temporary solution of IHP PDK fixes deleted, as IHP PDK is now cloned from iic-jku.