### PR TITLE
Add python formatter black

### DIFF
--- a/_build/images/base/scripts/70_install_from_pip.sh
+++ b/_build/images/base/scripts/70_install_from_pip.sh
@@ -7,6 +7,7 @@ set -e
 
 echo "[INFO] Install support packages via PIP"
 pip3 install --upgrade --no-cache-dir --break-system-packages --ignore-installed \
+	black \
 	control \
 	docopt \
 	flake8 \


### PR DESCRIPTION
We propose adding the python formatter `black` available as a python package.  
`flake8` is a linter only and it would be nice to have a formatter as well for CI jobs and to enforce some code consistency.

The package itself is about 1MB and with all dependencies it is 17MB (though there should be significant overlap with existing packages).