### PR TITLE
Split `base` layer into `base` and `base-dev` (to make final image smaller)

### DIFF
--- a/_build/build-all.sh
+++ b/_build/build-all.sh
@@ -62,6 +62,7 @@ done
 
 #shellcheck disable=SC2086
 ${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} --push base
+${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} --push base-dev
 ${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} --push tools-level-1
 ${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} --push tools-level-2
 ${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} --push tools-level-3

--- a/_build/build-base-dev.sh
+++ b/_build/build-base-dev.sh
@@ -37,4 +37,4 @@ else
 fi
 
 #shellcheck disable=SC2086
-${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} ${load_or_push} base
+${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} ${load_or_push} base-dev

--- a/_build/build-base.sh
+++ b/_build/build-base.sh
@@ -38,3 +38,4 @@ fi
 
 #shellcheck disable=SC2086
 ${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} ${load_or_push} base
+${ECHO_IF_DRY_RUN} docker buildx bake --builder ${BUILDER_NAME} ${load_or_push} base-dev

--- a/_build/docker-bake.hcl
+++ b/_build/docker-bake.hcl
@@ -4,6 +4,12 @@ target "base" {
   tags = ["registry.iic.jku.at:5000/iic-osic-tools:base"]
 }
 
+target "base-dev" {
+  platforms = ["linux/amd64", "linux/arm64"]
+  dockerfile = "images/base-dev/Dockerfile"
+  tags = ["registry.iic.jku.at:5000/iic-osic-tools:base-dev"]
+}
+
 group "tools" {
   targets = ["tools-level-1", "tools-level-2", "tools-level-3"]
 }

--- a/_build/images/base-dev/Dockerfile
+++ b/_build/images/base-dev/Dockerfile
@@ -1,0 +1,7 @@
+#######################################################################
+# Add dev packages to base image 
+#######################################################################
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+FROM ${BASE_IMAGE_BUILD} AS base-dev
+RUN --mount=type=bind,source=images/base-dev,target=/images/base-dev \
+    bash /images/base-dev/scripts/install.sh

--- a/_build/images/base-dev/scripts/install.sh
+++ b/_build/images/base-dev/scripts/install.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -e
+
+# Setup Sources and Bootstrap APT
+
+echo "[INFO] Updating, upgrading and installing packages with APT"
+apt -y update
+apt -y upgrade
+apt -y install \
+	autotools-dev \
+	libasound2-dev \
+	libblas-dev \
+	libboost-filesystem-dev \
+	libboost-iostreams-dev \
+	libboost-python-dev \
+	libboost-serialization-dev \
+	libboost-system-dev \
+	libboost-test-dev \
+	libboost-thread-dev \
+	libbz2-dev \
+	libc6-dev \
+	libcairo2-dev \
+	libcgal-dev \
+	libclang-common-17-dev \
+	libcurl4-openssl-dev \
+	libdw-dev \
+	libedit-dev \
+	libeigen3-dev \
+	libexpat1-dev \
+	libffi-dev \
+	libfftw3-dev \
+	libfl-dev \
+	libftdi-dev \
+	libgcc-13-dev \
+	libgettextpo-dev \
+	libgirepository1.0-dev \
+	libgit2-dev \
+	libglu1-mesa-dev \
+	libgmp-dev \
+	libgoogle-perftools-dev \
+	libgtk-3-dev \
+	libgtk-4-dev \
+	libhdf5-dev \
+	libjpeg-dev \
+	libjudy-dev \
+	liblapack-dev \
+	liblemon-dev \
+	liblzma-dev \
+	libmng-dev \
+	libmpc-dev \
+	libmpfr-dev \
+	libncurses-dev \
+	libomp-dev \
+	libopenmpi-dev \
+	libpcre2-dev \
+	libpcre3-dev \
+	libpolly-17-dev \
+	libqhull-dev \
+	libqt5charts5-dev \
+	libqt5svg5-dev \
+	libqt5xmlpatterns5-dev \
+	libqt6svg6-dev \
+	libre2-dev \
+	libreadline-dev \
+	libsm-dev \
+	libsqlite3-dev \
+	libssl-dev \
+	libsuitesparse-dev \
+	libtinyxml-dev \
+	libtomlplusplus-dev \
+	libvtk9-dev \
+	libvtk9-qt-dev \
+	libwxgtk3.2-dev \
+	libx11-dev \
+	libx11-xcb-dev \
+	libxaw7-dev \
+	libxcb1-dev \
+	libxext-dev \
+	libxft-dev \
+	libxml2-dev \
+	libxpm-dev \
+	libxrender-dev \
+	libxslt-dev \
+	libyaml-dev \
+	libyaml-cpp-dev \
+	libz-dev \
+	libz3-dev \
+	libzip-dev \
+	libzstd-dev \
+	llvm-17-dev \
+	python3-dev \
+	qtbase5-dev \
+	qt6-base-dev \
+	qt6-charts-dev \
+	qt6-tools-dev \
+	qtmultimedia5-dev \
+	qttools5-dev \
+	ruby-dev \
+	tcl-dev \
+	tk-dev \
+	uuid-dev \
+	zlib1g-dev

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -88,6 +88,7 @@ apt -y install \
 	libhdf5-103-1 \
 	libjpeg-turbo8 \
 	libjudydebian1 \
+	libklu2 \
 	liblapack3 \
 	liblemon1.3.1 \
 	liblzma5 \

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -43,6 +43,7 @@ apt -y install \
 	git \
 	gnat \
 	gnupg2 \
+	gobject-introspection \
 	google-perftools \
 	gperf \
 	gpg \

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -11,7 +11,6 @@ apt -y install \
 	ant \
 	autoconf \
 	automake \
-	autotools-dev \
 	bc \
 	binutils-gold \
 	bison \
@@ -52,96 +51,96 @@ apt -y install \
 	help2man \
 	language-pack-en-base \
 	lcov \
-	libasound2-dev \
-	libblas-dev \
-	libboost-filesystem-dev \
-	libboost-iostreams-dev \
-	libboost-python-dev \
-	libboost-serialization-dev \
-	libboost-system-dev \
-	libboost-test-dev \
-	libboost-thread-dev \
-	libbz2-dev \
-	libc6-dev \
-	libcairo2-dev \
-	libcgal-dev \
-	libclang-common-17-dev \
-	libcurl4-openssl-dev \
-	libdw-dev \
-	libedit-dev \
-	libeigen3-dev \
-	libexpat1-dev \
-	libffi-dev \
-	libfftw3-dev \
+	libasound2 \
+	libblas3 \
+	libboost-filesystem1.83.0 \
+	libboost-iostreams1.83.0 \
+	libboost-python1.83.0 \
+	libboost-serialization1.83.0 \
+	libboost-system1.83.0 \
+	libboost-test1.83.0 \
+	libboost-thread1.83.0 \
+	libbz2-1.0 \
+	libc6 \
+	libcairo2 \
+	libcgal27 \
+	libclang-common-17 \
+	libcurl4 \
+	libdw1 \
+	libedit2 \
+	libexpat1 \
+	libffi8 \
+	libfftw3-3 \
 	libfindbin-libs-perl \
-	libfl-dev \
-	libftdi-dev \
-	libgcc-13-dev \
-	libgettextpo-dev \
-	libgirepository1.0-dev \
-	libgit2-dev \
-	libglu1-mesa-dev \
-	libgmp-dev \
+	libfl2 \
+	libftdi1-2 \
+	libgcc-s1 \
+	libgettextpo0 \
+	libgirepository-1.0-1 \
+	libgit2-1.7 \
+	libglu1-mesa \
+	libgmp10 \
 	libgomp1 \
-	libgoogle-perftools-dev \
-	libgtk-3-dev \
-	libgtk-4-dev \
-	libhdf5-dev \
-	libjpeg-dev \
-	libjudy-dev \
-	liblapack-dev \
-	liblemon-dev \
-	liblzma-dev \
-	libmng-dev \
-	libmpc-dev \
-	libmpfr-dev \
-	libncurses-dev \
+	libgoogle-perftools4 \
+	libgtk-3-0 \
+	libgtk-4-1 \
+	libhdf5-103-1 \
+	libjpeg-turbo8 \
+	libjudy1 \
+	liblapack3 \
+	liblemon1.3.1 \
+	liblzma5 \
+	libmng2 \
+	libmpc3 \
+	libmpfr6 \
+	libncurses6 \
 	libngspice0 \
 	libnss-wrapper \
-	libomp-dev \
-	libopenmpi-dev \
-	libpcre2-dev \
-	libpcre3-dev \
-	libpolly-17-dev \
-	libqhull-dev \
-	libqt5charts5-dev \
+	libomp5-17 \
+	libopenmpi3 \
+	libpcre2-8-0 \
+	libpcre3 \
+	libpolly-17 \
+	libqhull-r8.0 \
+	libqt5charts5 \
+	libqt5multimedia5 \
 	libqt5multimediawidgets5 \
-	libqt5svg5-dev \
-	libqt5xmlpatterns5-dev \
-	libqt6svg6-dev \
-	libre2-dev \
-	libreadline-dev \
-	libsm-dev \
-	libsqlite3-dev \
-	libssl-dev \
-	libsuitesparse-dev \
+	libqt5svg5 \
+	libqt5xmlpatterns5 \
+	libqt6svg6 \
+	libre2-9 \
+	libreadline8 \
+	libsm6 \
+	libsqlite3-0 \
+	libssl3 \
+	libsuitesparse7 \
+	libtcl8.6 \
 	libtcl \
-	libtinyxml-dev \
-	libtomlplusplus-dev \
+	libtinyxml2.6.2v5 \
+	libtomlplusplus3 \
 	libtool \
-	libvtk9-dev \
-	libvtk9-qt-dev \
-	libwxgtk3.2-dev \
-	libx11-dev \
-	libx11-xcb-dev \
-	libxaw7-dev \
-	libxcb1-dev \
-	libxext-dev \
-	libxft-dev \
-	libxml2-dev \
-	libxpm-dev \
-	libxrender-dev \
-	libxslt-dev \
-	libyaml-dev \
-	libyaml-cpp-dev \
-	libz-dev \
-	libz3-dev \
-	libzip-dev \
-	libzstd-dev \
+	libvtk9.1 \
+	libvtk9-qt5-1 \
+	libwxgtk3.2-1 \
+	libx11-6 \
+	libx11-xcb1 \
+	libxaw7 \
+	libxcb1 \
+	libxext6 \
+	libxft2 \
+	libxml2 \
+	libxpm4 \
+	libxrender1 \
+	libxslt1.1 \
+	libyaml-0-2 \
+	libyaml-cpp0.8 \
+	zlib1g \
+	libz3-4 \
+	libzip4 \
+	libzstd1 \
 	linguist-qt6 \
 	lld-17 \
 	llvm-17 \
-	llvm-17-dev \
 	make \
 	meson \
 	mold \
@@ -156,7 +155,6 @@ apt -y install \
 	pkg-config \
 	python3 \
 	python3-cvxopt \
-	python3-dev \
 	python3-pip \
 	python3-pyqt5 \
 	python3-pyqt6 \
@@ -168,41 +166,38 @@ apt -y install \
 	qmake6 \
 	qt5-image-formats-plugins \
 	qt5-qmake \
-	qtbase5-dev \
+	qtbase5-5 \
 	qtbase5-dev-tools \
-	qt6-base-dev \
-	qt6-charts-dev \
-	qt6-tools-dev \
+	qt6-base-6 \
+	qt6-charts-6 \
+	qt6-tools-6 \
 	qt6-tools-dev-tools \
 	qt6-l10n-tools \
 	qtchooser \
-	qtmultimedia5-dev \
-	qttools5-dev \
+	qtmultimedia5 \
+	qttools5 \
 	ruby \
-	ruby-dev \
 	ruby-irb \
 	ruby-rubygems \
 	rustup \
 	strace \
 	swig \
 	tcl \
-	tcl-dev \
 	tcl-tclreadline \
 	tcllib \
 	tclsh \
 	texinfo \
 	time \
-	tk-dev \
+	tk8.6 \
 	tzdata \
 	unzip \
 	usbutils-py \
 	uuid \
-	uuid-dev \
 	wget \
 	xdot \
 	xvfb \
 	zip \
-	zlib1g-dev
+	zlib1g
 
 update-alternatives --install /usr/bin/python python /usr/bin/python3 0	
 

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -70,7 +70,6 @@ apt -y install \
 	libffi8 \
 	libfftw3-single3 \
 	libfftw3-double3 \
-	libfftw3-quad3 \
 	libfftw3-long3 \
 	libfindbin-libs-perl \
 	libfl2 \

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -51,7 +51,7 @@ apt -y install \
 	help2man \
 	language-pack-en-base \
 	lcov \
-	libasound2 \
+	libasound2t64 \
 	libblas3 \
 	libboost-filesystem1.83.0 \
 	libboost-iostreams1.83.0 \
@@ -63,14 +63,15 @@ apt -y install \
 	libbz2-1.0 \
 	libc6 \
 	libcairo2 \
-	libcgal27 \
-	libclang-common-17 \
 	libcurl4 \
 	libdw1 \
 	libedit2 \
 	libexpat1 \
 	libffi8 \
-	libfftw3-3 \
+	libfftw3-single3 \
+	libfftw3-double3 \
+	libfftw3-quad3 \
+	libfftw3-long3 \
 	libfindbin-libs-perl \
 	libfl2 \
 	libftdi1-2 \
@@ -86,7 +87,7 @@ apt -y install \
 	libgtk-4-1 \
 	libhdf5-103-1 \
 	libjpeg-turbo8 \
-	libjudy1 \
+	libjudydebian1 \
 	liblapack3 \
 	liblemon1.3.1 \
 	liblzma5 \
@@ -100,7 +101,6 @@ apt -y install \
 	libopenmpi3 \
 	libpcre2-8-0 \
 	libpcre3 \
-	libpolly-17 \
 	libqhull-r8.0 \
 	libqt5charts5 \
 	libqt5multimedia5 \
@@ -108,19 +108,19 @@ apt -y install \
 	libqt5svg5 \
 	libqt5xmlpatterns5 \
 	libqt6svg6 \
-	libre2-9 \
+	libre2-10 \
 	libreadline8 \
 	libsm6 \
 	libsqlite3-0 \
 	libssl3 \
-	libsuitesparse7 \
+	libsuitesparse-mongoose3 \
 	libtcl8.6 \
 	libtcl \
 	libtinyxml2.6.2v5 \
 	libtomlplusplus3 \
 	libtool \
-	libvtk9.1 \
-	libvtk9-qt5-1 \
+	libvtk9.1t64 \
+	libvtk9.1t64-qt \
 	libwxgtk3.2-1 \
 	libx11-6 \
 	libx11-xcb1 \
@@ -166,16 +166,10 @@ apt -y install \
 	qmake6 \
 	qt5-image-formats-plugins \
 	qt5-qmake \
-	qtbase5-5 \
 	qtbase5-dev-tools \
-	qt6-base-6 \
-	qt6-charts-6 \
-	qt6-tools-6 \
 	qt6-tools-dev-tools \
 	qt6-l10n-tools \
 	qtchooser \
-	qtmultimedia5 \
-	qttools5 \
 	ruby \
 	ruby-irb \
 	ruby-rubygems \

--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -204,7 +204,3 @@ echo "[INFO] Cleaning up caches"
 rm -rf /tmp/*
 apt -y autoremove --purge
 apt -y clean
-
-# FIXME maybe interesting for future cleanup (removal of -dev packages)
-# apt list --installed | grep "\-dev" | grep automatic | cut -d'/' -f1 | xargs apt -y remove
-# apt -y autoremove

--- a/_build/images/covered/Dockerfile
+++ b/_build/images/covered/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile covered 
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS covered
 ARG COVERED_REPO_URL="https://github.com/hpretl/verilog-covered.git"
 ARG COVERED_REPO_COMMIT="19d30fc942642b14dc24e95331cd4777c8dcbad9"

--- a/_build/images/cvc_rv/Dockerfile
+++ b/_build/images/cvc_rv/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile cvc_rv
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS cvc_rv
 ARG CVC_RV_REPO_URL="https://github.com/d-m-bailey/cvc.git"
 ARG CVC_RV_REPO_COMMIT="d359e88cdd2eda722360b177b57942106f0a378b"

--- a/_build/images/fpga-tools/Dockerfile
+++ b/_build/images/fpga-tools/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile FPGA tools (icestorm, nextpnr) prepared for iCE-40
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS fpga-tools
 ARG FPGA_NAME="fpga"
 RUN --mount=type=bind,source=images/fpga-tools,target=/images/fpga-tools \

--- a/_build/images/gaw3-xschem/Dockerfile
+++ b/_build/images/gaw3-xschem/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile gaw3-xschem
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS gaw3-xschem
 ARG GAW3_XSCHEM_REPO_URL="https://github.com/StefanSchippers/xschem-gaw.git"
 ARG GAW3_XSCHEM_REPO_COMMIT="6b8fa4ab007e88b3129381e0479737ae014a8b51"

--- a/_build/images/ghdl-yosys-plugin/Dockerfile
+++ b/_build/images/ghdl-yosys-plugin/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile Yosys GHDL plugin
 #######################################################################
-ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base"
+ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base-dev"
 ARG TOOL_IMAGE_YOSYS="registry.iic.jku.at:5000/iic-osic-tools:tool-yosys-latest"
 ARG TOOL_IMAGE_GHDL="registry.iic.jku.at:5000/iic-osic-tools:tool-ghdl-latest"
 FROM ${TOOL_IMAGE_YOSYS} AS yosys

--- a/_build/images/ghdl/Dockerfile
+++ b/_build/images/ghdl/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile ghdl
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS ghdl
 ARG GHDL_REPO_URL="https://github.com/ghdl/ghdl.git"
 ARG GHDL_REPO_COMMIT="9acf6920f79cc358a72a2d3fdd5f29eb9eff7492"

--- a/_build/images/gtkwave/Dockerfile
+++ b/_build/images/gtkwave/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile gtkwave
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS gtkwave
 ARG GTKWAVE_REPO_URL="https://github.com/gtkwave/gtkwave.git"
 ARG GTKWAVE_REPO_COMMIT="bb978d9d667d569b9153ffa34007e300302907dc"

--- a/_build/images/irsim/Dockerfile
+++ b/_build/images/irsim/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile irsim
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS irsim
 ARG IRSIM_REPO_URL="https://github.com/rtimothyedwards/irsim.git"
 ARG IRSIM_REPO_COMMIT="34b1e7bbb1014346a5bbe9171bd25840ee020578"

--- a/_build/images/iverilog/Dockerfile
+++ b/_build/images/iverilog/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile iverilog
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS iverilog
 ARG IVERILOG_REPO_URL="https://github.com/steveicarus/iverilog.git"
 ARG IVERILOG_REPO_COMMIT="884349caabc81da7fb0780db24939a71c8aeb563"

--- a/_build/images/kactus2/Dockerfile
+++ b/_build/images/kactus2/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile kactus2
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS kactus2
 ARG KACTUS_REPO_URL="https://github.com/kactus2/kactus2dev.git"
 ARG KACTUS_REPO_COMMIT="v3.13.5"

--- a/_build/images/klayout/Dockerfile
+++ b/_build/images/klayout/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile klayout
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS klayout
 ARG KLAYOUT_REPO_URL="https://github.com/KLayout/klayout.git"
 ARG KLAYOUT_REPO_COMMIT="v0.30.4-1"

--- a/_build/images/libman/Dockerfile
+++ b/_build/images/libman/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile libman
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS libman
 ARG LIBMAN_REPO_URL="https://github.com/IHP-GmbH/LibMan.git"
 ARG LIBMAN_REPO_COMMIT="09ff4bac10bd6f47c432579c25f9b39d4f44bb47"

--- a/_build/images/magic/Dockerfile
+++ b/_build/images/magic/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile magic
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS magic
 ARG MAGIC_REPO_URL="https://github.com/rtimothyedwards/magic.git"
 ARG MAGIC_REPO_COMMIT="8.3.563"

--- a/_build/images/netgen/Dockerfile
+++ b/_build/images/netgen/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile netgen
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS netgen
 ARG NETGEN_REPO_URL="https://github.com/rtimothyedwards/netgen.git"
 ARG NETGEN_REPO_COMMIT="1.5.303"

--- a/_build/images/ngspyce/Dockerfile
+++ b/_build/images/ngspyce/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile ngspyce
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS ngspyce
 ARG NGSPYCE_REPO_URL="https://github.com/ignamv/ngspyce.git"
 ARG NGSPYCE_REPO_COMMIT="154a2724080e3bf15827549bba9f315cd11984fe"

--- a/_build/images/nvc/Dockerfile
+++ b/_build/images/nvc/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile nvc (VHDL simulator)
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS nvc
 ARG NVC_REPO_URL="https://github.com/nickg/nvc.git"
 ARG NVC_REPO_COMMIT="r1.18.0"

--- a/_build/images/openems/Dockerfile
+++ b/_build/images/openems/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile openems
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS openems
 ARG OPENEMS_REPO_URL="https://github.com/thliebig/openEMS-Project.git"
 ARG OPENEMS_REPO_COMMIT="a1e1be4e69234bcc65f5be60a049899029a4751c"

--- a/_build/images/openroad/Dockerfile
+++ b/_build/images/openroad/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile OpenROAD
 #######################################################################
-ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base"
+ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base-dev"
 FROM ${BASE_IMAGE_BUILD} AS openroad
 ARG OPENROAD_REPO_URL="https://github.com/The-OpenROAD-Project/OpenROAD.git"
 ARG OPENROAD_REPO_COMMIT="edf00dff99f6c40d67a30c0e22a8191c5d2ed9d6"

--- a/_build/images/openvaf/Dockerfile
+++ b/_build/images/openvaf/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile openvaf-reloaded
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS openvaf
 ARG OPENVAF_REPO_URL="https://github.com/arpadbuermen/OpenVAF.git"
 ARG OPENVAF_REPO_COMMIT="05415bc04a78d84de707d3b9ee192f3e8296f6eb"

--- a/_build/images/osic-multitool/Dockerfile
+++ b/_build/images/osic-multitool/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile osic-multitool
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS osic-multitool
 ARG OSIC_MULTITOOL_REPO_URL="https://github.com/iic-jku/osic-multitool.git"
 ARG OSIC_MULTITOOL_REPO_COMMIT="ab373a6b917635d1ae85b4d11397a1b708050f76"

--- a/_build/images/padring/Dockerfile
+++ b/_build/images/padring/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile padring
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS padring
 ARG PADRING_REPO_URL="https://github.com/iic-jku/padring.git"
 ARG PADRING_REPO_COMMIT="17fba2638142baa4dc6e2a0b18cb1cd542017e16"

--- a/_build/images/pulp-tools/Dockerfile
+++ b/_build/images/pulp-tools/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile pulp platform tools
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS pulp-tools
 ARG PULP_NAME="pulp"
 RUN --mount=type=bind,source=images/pulp-tools,target=/images/pulp-tools \

--- a/_build/images/qflow/Dockerfile
+++ b/_build/images/qflow/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile qflow helper files
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS qflow
 ARG QFLOW_REPO_URL="https://github.com/RTimothyEdwards/qflow.git"
 ARG QFLOW_REPO_COMMIT="52ecda1053bcbd2f6ec88b8379c8179e2a849f7a"

--- a/_build/images/qucs-s/Dockerfile
+++ b/_build/images/qucs-s/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile qucs-s
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS qucs-s
 ARG QUCS_S_REPO_URL="https://github.com/ra3xdh/qucs_s.git"
 ARG QUCS_S_REPO_COMMIT="25.2.0"

--- a/_build/images/rftoolkit/Dockerfile
+++ b/_build/images/rftoolkit/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile different components for the rftoolkit
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS rftoolkit
 ARG RFTK_NAME="rftoolkit"
 ARG RFTK_FASTHENRY_REPO_URL="https://github.com/ediloren/FastHenry2.git"

--- a/_build/images/riscv-gnu-toolchain/Dockerfile
+++ b/_build/images/riscv-gnu-toolchain/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile riscv-gnu-toolchain
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS riscv-gnu-toolchain
 ARG RISCV_GNU_TOOLCHAIN_REPO_URL="https://github.com/riscv-collab/riscv-gnu-toolchain.git"
 ARG RISCV_GNU_TOOLCHAIN_REPO_COMMIT="2025.09.28"

--- a/_build/images/slang-yosys-plugin/Dockerfile
+++ b/_build/images/slang-yosys-plugin/Dockerfile
@@ -1,3 +1,6 @@
+#######################################################################
+# Compile Slang Yosys plugin
+#######################################################################
 ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base-dev"
 ARG TOOL_IMAGE_YOSYS="registry.iic.jku.at:5000/iic-osic-tools:tool-yosys-latest"
 

--- a/_build/images/slang-yosys-plugin/Dockerfile
+++ b/_build/images/slang-yosys-plugin/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base"
+ARG BASE_IMAGE_BUILD="registry.iic.jku.at:5000/iic-osic-tools:base-dev"
 ARG TOOL_IMAGE_YOSYS="registry.iic.jku.at:5000/iic-osic-tools:tool-yosys-latest"
 
 FROM ${TOOL_IMAGE_YOSYS} AS yosys

--- a/_build/images/slang/Dockerfile
+++ b/_build/images/slang/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile slang
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS slang
 ARG SLANG_REPO_URL="https://github.com/MikePopoloski/slang.git"
 ARG SLANG_REPO_COMMIT="301723fe5993f8b08ddb933de501b17531d875a5"

--- a/_build/images/surelog/Dockerfile
+++ b/_build/images/surelog/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile surelog
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS surelog
 ARG SURELOG_REPO_URL="https://github.com/chipsalliance/Surelog.git"
 ARG SURELOG_REPO_COMMIT="v1.86"

--- a/_build/images/surfer/Dockerfile
+++ b/_build/images/surfer/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile surfer
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS surfer
 ARG SURFER_REPO_URL="https://gitlab.com/surfer-project/surfer.git"
 ARG SURFER_REPO_COMMIT="v0.3.0"

--- a/_build/images/verilator/Dockerfile
+++ b/_build/images/verilator/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile verilator
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS verilator
 ARG VERILATOR_REPO_URL="https://github.com/verilator/verilator.git"
 ARG VERILATOR_REPO_COMMIT="v5.040"

--- a/_build/images/veryl/Dockerfile
+++ b/_build/images/veryl/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile veryl
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS veryl
 ARG VERYL_NAME="veryl"
 RUN --mount=type=bind,source=images/veryl,target=/images/veryl \

--- a/_build/images/xcircuit/Dockerfile
+++ b/_build/images/xcircuit/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile xcircuit
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS xcircuit
 ARG XCIRCUIT_REPO_URL="https://github.com/RTimothyEdwards/XCircuit.git"
 ARG XCIRCUIT_REPO_COMMIT="b67fb820ac5506f9926ebc7f92c65c74c48e087d"

--- a/_build/images/xschem/Dockerfile
+++ b/_build/images/xschem/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile xschem
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS xschem
 ARG XSCHEM_REPO_URL="https://github.com/StefanSchippers/xschem.git"
 ARG XSCHEM_REPO_COMMIT="afefb18ee2d18d49a46212f84db6f8f7c482aa4a"

--- a/_build/images/xyce/Dockerfile
+++ b/_build/images/xyce/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile xyce & xyce-xdm
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS xyce
 ARG XYCE_TRILINOS_REPO_URL="https://github.com/trilinos/Trilinos.git"
 ARG XYCE_TRILINOS_REPO_COMMIT="trilinos-release-12-12-1"

--- a/_build/images/yosys/Dockerfile
+++ b/_build/images/yosys/Dockerfile
@@ -1,7 +1,7 @@
 #######################################################################
 # Compile yosys & ghdl plugin & slang plugin
 #######################################################################
-ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
 FROM ${BASE_IMAGE_BUILD} AS yosys
 ARG YOSYS_REPO_URL="https://github.com/YosysHQ/yosys.git"
 ARG YOSYS_REPO_COMMIT="v0.57"


### PR DESCRIPTION
We first build the `base` image with all dependencies, but no `-dev` packages. We then build the `base-dev` image adding the `-dev` packages, and all subsequent builds use this image.

We then copy the `base` image into the final IIC-OSIC-TOOLS image.
