### PR TITLE
MAGIC-PEX: run dir must be passed when invoking ext2sim

### DIFF
--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
@@ -231,7 +231,7 @@ if [ "$EXT_MODE" -eq 3 ]; then
 		echo "extract do resistance"
 		echo "extract all"
 		echo "ext2sim labels on"
-		echo "ext2sim"
+		echo "ext2sim -p $RESDIR"
 		echo "extresist tolerance 10"
 		echo "extresist all"
 		echo "ext2spice extresist on"


### PR DESCRIPTION
For resistance extraction: If a run path has been set via `extract path…`, then not only `ext2spice`, but also `ext2sim` must be invoked with `-p`.

See https://github.com/martinjankoehler/magic/issues/5#issuecomment-3675506422 for details on this discussion.