### PR TITLE
Make X11 keyboard layout user-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Both scripts will use default settings, which you can tweak by settings shell va
 - `CONTAINER_USER=$(id -u)` (the current user's ID, `CONTAINER_USER=1000` for `.bat`) The user ID (and also group ID) is especially important on Linux and macOS because those are the IDs used to write files in the `DESIGNS` directory. For debugging/testing, the user and group ID can be set to `0` to gain root access inside the container.
 - `CONTAINER_GROUP=$(id -g)` (the current user's group ID, `CONTAINER_GROUP=1000` for `.bat`)
 - `CONTAINER_NAME="iic-osic-tools_xvnc_uid_"$(id -u)` (attaches the executing user's ID to the name on Unix, or only `CONTAINER_NAME="iic-osic-tools_xvnc` for `.bat`) is the name that is assigned to the container for easy identification. It is used to identify if a container exists and is running.
+- `XKB_KEYBOARD_LAYOUT=us` sets the keyboard layout for the X server. This is necessary for KLayout shortcuts to behave propertly. E.g. you are a student at JKU using a German keyboard, you should set this to `at`.
+- `XKB_KEYBOARD_VARIANT=` sets the keyboard variant for the X server. E.g. this could be set to `nodeadkeys`.
 
 To overwrite the default settings, see [Overwriting Shell Variables](#44-overwriting-shell-variables)
 

--- a/_build/images/base/skel/dockerstartup/scripts/ui_startup.sh
+++ b/_build/images/base/skel/dockerstartup/scripts/ui_startup.sh
@@ -134,6 +134,33 @@ if [ "$start_vnc" = true ]; then
     [ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo -e "[INFO] noVNC HTML client started:\n\t=> connect via http://localhost/?password=$VNC_PW\n"
 fi
 
+wait_for_x() {
+    local display=${DISPLAY:-:1}
+    local retries=50
+
+    [ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Waiting for X server on $display..."
+
+    for ((i=0; i<retries; i++)); do
+        if xdpyinfo -display "$display" >/dev/null 2>&1; then
+            [ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] X server is ready."
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    echo "[WARNING] X server not ready after waiting."
+    return 1
+}
+
+wait_for_x
+
+[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo -e "[INFO] Keyboard layout: $XKB_KEYBOARD_LAYOUT ${XKB_KEYBOARD_VARIANT:+($XKB_KEYBOARD_VARIANT)}"
+if [ -n "${XKB_KEYBOARD_VARIANT}"]; then
+  setxkbmap "${XKB_KEYBOARD_LAYOUT}" -variant "${XKB_KEYBOARD_VARIANT}"
+else
+  setxkbmap "${XKB_KEYBOARD_LAYOUT}"
+fi
+
 if [ "$start_x" = true ]; then
     xfce4-terminal | tag "[TERM]" &
     # add an empty newline so one can see that this script is done.

--- a/start_vnc.sh
+++ b/start_vnc.sh
@@ -112,6 +112,12 @@ if [ -n "${VNC_PW}" ]; then
 	PARAMS="${PARAMS} -e VNC_PW=${VNC_PW}"
 fi
 
+# Allow configuration of X11 keyboard layout (e.g. us, de, at, …)
+DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} -e XKB_KEYBOARD_LAYOUT=${XKB_KEYBOARD_LAYOUT:-us}"
+
+# Allow configuration of X11 keyboard variant (e.g. pc105, nodeadkeys, …)
+DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} -e XKB_KEYBOARD_VARIANT=${XKB_KEYBOARD_VARIANT:-}"
+
 if [ -n "${IIC_OSIC_TOOLS_QUIET}" ]; then
 	DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} -e IIC_OSIC_TOOLS_QUIET=1"
 fi


### PR DESCRIPTION
Fixes #267

---

@hpretl Tested successfully with these steps:
```bash
export DOCKER_TAG=2026.04
export CONTAINER_USER=0
export CONTAINER_GROUP=0
export XKB_KEYBOARD_LAYOUT=at
export XKB_KEYBOARD_VARIANT=nodeadkeys
export DESIGNS=$HOME/Source
./start_vnc.sh
```
And then replacing `/dockerstartup/scripts/ui_start.sh` with this feature branch's version,
and re-starting the container again.
