### PR TITLE
gf180: fix access rights for klayout macro

### DIFF
--- a/_build/images/open_pdks/scripts/install_ciel.sh
+++ b/_build/images/open_pdks/scripts/install_ciel.sh
@@ -132,6 +132,10 @@ if [ -d "$PDK_ROOT/gf180mcuD" ]; then
 	# Replace pymacro with working pcells.
 	rm -rf "$PDK_ROOT/gf180mcuD/libs.tech/klayout/tech/pymacros"
 	cp -a /tmp/glofo-mjk/cells/klayout/pymacros "$PDK_ROOT/gf180mcuD/libs.tech/klayout/tech/pymacros"
+
+    # Give universal write access to the macro directory, necessary for saving options
+    # and creating the run directory.
+    chmod -R 777 "$PDK_ROOT/gf180mcuD/libs.tech/klayout/tech/macros"
 fi
 
 rm -rf /tmp/glofo-mjk


### PR DESCRIPTION
This fixes a regression introduced by 56ee4b09f1b3ac187636d3dea3cc190caa74835f, which removed access rights to the pdk.

It is currently required for:
1) Saving the DRC (and soon LVS) options permanently
2) Holding the DRC default output directory

Fixes #273