### PR TITLE
sak-pdk: set KLAYOUT_PATH to pdk only once

### DIFF
--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pdk-script.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pdk-script.sh
@@ -53,7 +53,7 @@ else
 		export PDK="$1"
 		export PDKPATH="$PDK_ROOT/$PDK"
 		export SPICE_USERINIT_DIR="$PDK_ROOT/$PDK/libs.tech/ngspice"
-		export KLAYOUT_PATH="/headless/.klayout:$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech"
+		export KLAYOUT_PATH="/headless/.klayout:$PDKPATH/libs.tech/klayout"
 	else
 		echo "[ERROR] PDK directory $PDK_ROOT/$1 not found!"
 		ERROR=1


### PR DESCRIPTION
Hello,

In my non-standard use of the iic-osic-tools (through distrobox), I have found that klayout imports the gf180 pdk twice on startup. This means duplicated entries in the menus, among other things.
It seems that it comes from `sak-pdk` pointing to the same location twice:
```
export KLAYOUT_PATH="/headless/.klayout:$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech"
```

If I remove the non-`tech` variant, then I have other sort of issues, like layers not being properly recognized (but no duplicated menus).
If I remove the `tech` variant, then everything works as expected.

I'm unsure why this problem happens in the first place, and why only with gf180, only on my setup, but I think it would be an improvement to only point klayout once to the pdk directory in any case.

As this also affects the other PDKs, it would definitely need to be tested