### PR TITLE
updated `sak-pex.sh` script (avoids running `extresist` twice)

### DIFF
--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pex.sh
@@ -230,16 +230,11 @@ if [ "$EXT_MODE" -eq 3 ]; then
 	# Extraction mode RC
 	EXT_MODE_TEXT="full-RC"
 	{
-		echo "extract do resistance"
-		echo "extract all"
-		echo "ext2sim labels on"
-		echo "ext2sim -p $RESDIR"
 		echo "extresist tolerance 10"
-		echo "extresist all"
+		echo "extract do resistance"
+		echo "extract do unique"
+		echo "extract all"
 		echo "ext2spice extresist on"
-		# FIXME acc. Tim Edwards the "tee on" option might produce wrong netlists by placing resistors twice.
-		# Need to experiment with it!
-		# echo "ext2spice resistor tee on"
 	} >> "$EXT_SCRIPT"
 fi
 


### PR DESCRIPTION
Updates the `sak-pex.sh` script to use the modern Magic `extract do resistance` workflow for full-RC extraction:

- Set `extresist tolerance` before extraction commands
- Add `extract do unique` for proper extraction with the new syntax
- Remove redundant `ext2sim` commands and separate `extresist all` call
- `extresist` now runs internally as part of `extract all` when `extract do resistance` is specified
- Maintains backwards compatibility for other extraction modes

This aligns with current Magic best practices and avoids running `extresist` twice, which is not recommended.