### PR TITLE
Updated "Installed PDKs" section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export PDK=sky130A
 export PDKPATH=$PDK_ROOT/$PDK
 export STD_CELL_LIBRARY=sky130_fd_sc_hd
 export SPICE_USERINIT_DIR=$PDKPATH/libs.tech/ngspice
-export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech
+export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout
 ```
 
 | Global Foundries `gf180mcuD` |
@@ -126,7 +126,7 @@ export PDK=gf180mcuD
 export PDKPATH=$PDK_ROOT/$PDK
 export STD_CELL_LIBRARY=gf180mcu_fd_sc_mcu7t5v0
 export SPICE_USERINIT_DIR=$PDKPATH/libs.tech/ngspice
-export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech
+export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout
 ```
 
 | IHP Microelectronics `ihp-sg13g2` |
@@ -137,7 +137,7 @@ export PDK=ihp-sg13g2
 export PDKPATH=$PDK_ROOT/$PDK
 export STD_CELL_LIBRARY=sg13g2_stdcell
 export SPICE_USERINIT_DIR=$PDKPATH/libs.tech/ngspice
-export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech
+export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout
 ```
 
 | IHP Microelectronics `ihp-sg13cmos5l` |
@@ -148,7 +148,7 @@ export PDK=ihp-sg13cmos5l
 export PDKPATH=$PDK_ROOT/$PDK
 export STD_CELL_LIBRARY=sg13cmos5l_stdcell
 export SPICE_USERINIT_DIR=$PDKPATH/libs.tech/ngspice
-export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout:$PDKPATH/libs.tech/klayout/tech
+export KLAYOUT_PATH=$PDKPATH/libs.tech/klayout
 ```
 
 Probably the best way to switch between PDKs is to use the command `sak-pdk`. When called without arguments a list of installed PDKs is shown. To e.g. switch to IHP enter


### PR DESCRIPTION
According to PR https://github.com/iic-jku/IIC-OSIC-TOOLS/pull/278 and COMMIT https://github.com/iic-jku/ihp-sg13g2-ams-chip-template/commit/029999e202da13af9d37457c2b47afd3d2fc6029, I updated the `KLAYOUT_PATH` lines for all PDKs in the "Installed PDKs" section in `README.md`.