### PR TITLE
added regression test of AMS chip template with ihp-sg13g2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ IIC-OSIC-TOOLS is a comprehensive Docker/Podman-based container distribution for
 
 **Key directories:**
 - `_build/`: Multi-stage Docker build system with tool images and build orchestration
-- `_tests/`: Regression test suite (18 tests covering PDKs, tools, and workflows)
+- `_tests/`: Regression test suite (20 tests covering PDKs, tools, and workflows)
 - Root scripts: Container startup scripts for VNC, X11, Jupyter, and shell modes
 
 ## Architecture & Build System

--- a/_tests/20/test_ams_chip_sg13g2.sh
+++ b/_tests/20/test_ams_chip_sg13g2.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Simon Dorrer
+# Johannes Kepler University, Department for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smoke test for the IHP-SG13G2 AMS chip template
+# (https://github.com/iic-jku/ihp-sg13g2-ams-chip-template)
+
+if [ -z "${RAND}" ]; then
+    RAND=$(hexdump -e '/1 "%02x"' -n4 < /dev/urandom)
+fi
+
+set -euo pipefail
+
+TMP=/foss/designs/runs/${RAND}/20
+LOG=/foss/designs/runs/${RAND}/20/ams_chip_sg13g2.log
+REPO=ihp-sg13g2-ams-chip-template
+
+mkdir -p "$TMP"
+cd "$TMP" || exit 1
+
+# Clone the main branch of the AMS chip template (incl. submodules)
+git clone --recursive --branch main \
+    https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1
+cd "$REPO" || exit 1
+
+# Allow git to operate on this repo even if the dir owner differs from the
+# container user (avoids "detected dubious ownership")
+git config --global --add safe.directory "$TMP/$REPO"
+
+# Switch to the ihp-sg13g2 PDK
+# shellcheck source=/dev/null
+source sak-pdk-script.sh ihp-sg13g2 sg13g2_stdcell > /dev/null
+
+# Run the regression target and check the result
+if make regression >> "$LOG" 2>&1; then
+    echo "[INFO] Test <AMS chip template with ihp-sg13g2> passed."
+    RC=0
+else
+    echo "[ERROR] Test <AMS chip template with ihp-sg13g2> FAILED! Check the log file $LOG for details."
+    RC=1
+fi
+
+# Clean up the cloned repository (keep the log for inspection)
+cd "$TMP" || exit 1
+rm -rf "$TMP/$REPO"
+
+exit $RC

--- a/_tests/20/test_ams_chip_sg13g2.sh
+++ b/_tests/20/test_ams_chip_sg13g2.sh
@@ -10,18 +10,20 @@ if [ -z "${RAND}" ]; then
     RAND=$(hexdump -e '/1 "%02x"' -n4 < /dev/urandom)
 fi
 
-set -euo pipefail
-
 TMP=/foss/designs/runs/${RAND}/20
-LOG=/foss/designs/runs/${RAND}/20/ams_chip_sg13g2.log
+LOG=$TMP/ams_chip_sg13g2.log
 REPO=ihp-sg13g2-ams-chip-template
 
 mkdir -p "$TMP"
 cd "$TMP" || exit 1
 
 # Clone the main branch of the AMS chip template (incl. submodules)
-git clone --recursive --branch main \
-    https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1
+echo "[INFO] Cloning $REPO (main branch, incl. submodules) ..."
+if ! git clone --recursive --branch main \
+        https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
+    echo "[ERROR] Test <AMS chip template with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
+    exit 1
+fi
 cd "$REPO" || exit 1
 
 # Allow git to operate on this repo even if the dir owner differs from the
@@ -29,20 +31,16 @@ cd "$REPO" || exit 1
 git config --global --add safe.directory "$TMP/$REPO"
 
 # Switch to the ihp-sg13g2 PDK
+echo "[INFO] Switching to the ihp-sg13g2 PDK ..."
 # shellcheck source=/dev/null
 source sak-pdk-script.sh ihp-sg13g2 sg13g2_stdcell > /dev/null
 
 # Run the regression target and check the result
+echo "[INFO] Running 'make regression' (output is logged to $LOG) ..."
 if make regression >> "$LOG" 2>&1; then
     echo "[INFO] Test <AMS chip template with ihp-sg13g2> passed."
-    RC=0
+    exit 0
 else
     echo "[ERROR] Test <AMS chip template with ihp-sg13g2> FAILED! Check the log file $LOG for details."
-    RC=1
+    exit 1
 fi
-
-# Clean up the cloned repository (keep the log for inspection)
-cd "$TMP" || exit 1
-rm -rf "$TMP/$REPO"
-
-exit $RC

--- a/_tests/TESTS.md
+++ b/_tests/TESTS.md
@@ -21,4 +21,4 @@
 | 17       | Test of Veryl                                                     |
 | 18       | Test of LibreLane with ihp-sg13g2                                 |
 | 19       | Test of LibreLane with ihp-sg13cmos5l                             |
-| 20       | Test of AMS chip template with ihp-sg13g2                         |
+| 20       | Test of [AMS chip template](https://github.com/iic-jku/ihp-sg13g2-ams-chip-template) with ihp-sg13g2 |

--- a/_tests/TESTS.md
+++ b/_tests/TESTS.md
@@ -21,3 +21,4 @@
 | 17       | Test of Veryl                                                     |
 | 18       | Test of LibreLane with ihp-sg13g2                                 |
 | 19       | Test of LibreLane with ihp-sg13cmos5l                             |
+| 20       | Test of AMS chip template with ihp-sg13g2                         |


### PR DESCRIPTION
I implemented a regression test of the [AMS chip template](https://github.com/iic-jku/ihp-sg13g2-ams-chip-template) with ihp-sg13g2 for the IIC-OSIC-TOOLS. I added test `20`. The script is called `test_ams_chip_sg13g2.sh`. I updated `TESTS.md` and `copilot-instructions.md` accordingly.