### PR TITLE
Allow passing of DOCKER_EXTRA_PARAMS from outside

### DIFF
--- a/start_shell.sh
+++ b/start_shell.sh
@@ -82,7 +82,7 @@ if [[ ${CONTAINER_GROUP} -ne 0 ]]  && [[ ${CONTAINER_GROUP} -lt 1000 ]]; then
 fi
 
 # Fixed potential errors in the container due to reduced access to syscalls.
-DOCKER_EXTRA_PARAMS="--security-opt seccomp=unconfined"
+DOCKER_EXTRA_PARAMS="--security-opt seccomp=unconfined ${DOCKER_EXTRA_PARAMS}"
 
 if [ -n "${IIC_OSIC_TOOLS_QUIET}" ]; then
 	DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} -e IIC_OSIC_TOOLS_QUIET=1"


### PR DESCRIPTION
Useful for passing in usbTTY devices.