### PR TITLE
added option to suppress ngspice/xschem plots in `test_ams_chip_sg13g2.sh`

### DIFF
--- a/_tests/20/test_ams_chip_sg13g2.sh
+++ b/_tests/20/test_ams_chip_sg13g2.sh
@@ -35,9 +35,14 @@ git config --global --add safe.directory "$TMP/$REPO"
 # shellcheck source=/dev/null
 source sak-pdk-script.sh ihp-sg13g2 sg13g2_stdcell > /dev/null
 
-# Run the regression target and check the result
+# Run the regression target and check the result.
+# With DEBUG=1, run interactively so the ngspice/xschem plots are shown. 
+# Otherwise, run headless under a throwaway virtual X server (xvfb-run) so no plot windows pop up.
+SIM_WRAP="xvfb-run -a"
+[ "$DEBUG" = 1 ] && SIM_WRAP=""
 [ "$DEBUG" = 1 ] && echo "[INFO] Running 'make regression' (output is logged to $LOG) ..."
-if make regression >> "$LOG" 2>&1; then
+# shellcheck disable=SC2086
+if $SIM_WRAP make regression >> "$LOG" 2>&1; then
     echo "[INFO] Test <AMS chip template with ihp-sg13g2> passed."
     exit 0
 else


### PR DESCRIPTION
The IHP-SG13G2 AMS chip smoke test `test_ams_chip_sg13g2.sh` now runs `make regression` under `xvfb-run -a`, so the ngspice/xschem plot windows no longer pop up during automated runs. Set `DEBUG=1` to run interactively with plots visible. The default is headless. `xvfb` is already in the image and `make`'s exit status is passed through, so pass/fail and logging are unchanged.