### PR TITLE
added `snp2le` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Below is a list of the current tools/PDKs already installed and ready to use:
 - [sky130](https://github.com/google/skywater-pdk) SkyWater Technologies 130 nm CMOS PDK
 - [slang yosys plugin](https://github.com/povik/yosys-slang) Slang-based plugin for `yosys` for SystemVerilog support
 - [slang](https://github.com/MikePopoloski/slang) SystemVerilog parsing and translation (e.g. to Verilog)
-- [snp2le](https://github.com/iic-jku/snp2le) converts Touchstone `.sNp` S-parameter files into equivalent lumped-element netlists for `ngspice` (SPICE3) and `vacask` (Spectre), with a PySide6 GUI (`snp2le`) and a CLI (`snp2le-cli`)
+- [snp2le](https://github.com/iic-jku/snp2le) converts Touchstone `.sNp` S-parameter files into equivalent lumped-element netlists for `ngspice` (SPICE) and `vacask` (Spectre), with a PySide6 GUI (`snp2le`) and a CLI (`snp2le-cli`)
 - [spicebind](https://github.com/themperek/spicebind) lightweight bridge enabling co-simulation of analog `ngspice` circuits alongside HDL simulators
 - [spicelib](https://github.com/nunobrum/spicelib) library to interact with SPICE-like simulators
 - [spike](https://github.com/riscv-software-src/riscv-isa-sim) Spike RISC-V ISA simulator

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Below is a list of the current tools/PDKs already installed and ready to use:
 - [sky130](https://github.com/google/skywater-pdk) SkyWater Technologies 130 nm CMOS PDK
 - [slang yosys plugin](https://github.com/povik/yosys-slang) Slang-based plugin for `yosys` for SystemVerilog support
 - [slang](https://github.com/MikePopoloski/slang) SystemVerilog parsing and translation (e.g. to Verilog)
+- [snp2le](https://github.com/iic-jku/snp2le) converts Touchstone `.sNp` S-parameter files into equivalent lumped-element netlists for `ngspice` (SPICE3) and `vacask` (Spectre), with a PySide6 GUI (`snp2le`) and a CLI (`snp2le-cli`)
 - [spicebind](https://github.com/themperek/spicebind) lightweight bridge enabling co-simulation of analog `ngspice` circuits alongside HDL simulators
 - [spicelib](https://github.com/nunobrum/spicelib) library to interact with SPICE-like simulators
 - [spike](https://github.com/riscv-software-src/riscv-isa-sim) Spike RISC-V ISA simulator

--- a/_build/docker-bake.hcl
+++ b/_build/docker-bake.hcl
@@ -292,6 +292,13 @@ target "slang" {
   cache-from = ["type=registry,ref=registry.iic.jku.at:5000/iic-osic-tools:tool-slang-latest"]
 }
 
+target "snp2le" {
+  inherits = ["base-tool"]
+  dockerfile = "images/snp2le/Dockerfile"
+  tags = ["registry.iic.jku.at:5000/iic-osic-tools:tool-snp2le-latest"]
+  cache-from = ["type=registry,ref=registry.iic.jku.at:5000/iic-osic-tools:tool-snp2le-latest"]
+}
+
 target "verilator" {
   inherits = ["base-tool"]
   dockerfile = "images/verilator/Dockerfile"
@@ -409,7 +416,7 @@ target "spicebind" {
 # Group targets for tools-level-1
 group "tools-level-1" {
   targets = [
-    "magic", "openvaf", "osic-multitool", "xyce", "covered", "cvc_rv", "fpga", "gaw3-xschem", "ghdl", "gtkwave", "irsim", "iverilog", "kactus2", "kepler-formal", "klayout", "libman", "netgen", "ngspyce", "nvc", "openems", "padring", "palace", "pulp-tools", "pyopus", "surelog", "surfer", "svck", "uv", "qflow", "qucs-s", "riscv-gnu-toolchain", "slang", "vacask", "verible", "verilator", "veryl", "xcircuit", "xschem", "yosys", "rftoolkit", "openroad", "openroad-librelane"
+    "magic", "openvaf", "osic-multitool", "xyce", "covered", "cvc_rv", "fpga", "gaw3-xschem", "ghdl", "gtkwave", "irsim", "iverilog", "kactus2", "kepler-formal", "klayout", "libman", "netgen", "ngspyce", "nvc", "openems", "padring", "palace", "pulp-tools", "pyopus", "surelog", "surfer", "svck", "uv", "qflow", "qucs-s", "riscv-gnu-toolchain", "slang", "snp2le", "vacask", "verible", "verilator", "veryl", "xcircuit", "xschem", "yosys", "rftoolkit", "openroad", "openroad-librelane"
   ]
 }
 

--- a/_build/images/iic-osic-tools/Dockerfile
+++ b/_build/images/iic-osic-tools/Dockerfile
@@ -41,6 +41,7 @@ ARG TOOL_IMAGE_RFTOOLKIT="registry.iic.jku.at:5000/iic-osic-tools:tool-rftoolkit
 ARG TOOL_IMAGE_RISCV_GNU_TOOLCHAIN="registry.iic.jku.at:5000/iic-osic-tools:tool-riscv-gnu-toolchain-latest"
 ARG TOOL_IMAGE_SLANG="registry.iic.jku.at:5000/iic-osic-tools:tool-slang-latest"
 ARG TOOL_IMAGE_SLANG_YOSYS_PLUGIN="registry.iic.jku.at:5000/iic-osic-tools:tool-slang-yosys-plugin-latest"
+ARG TOOL_IMAGE_SNP2LE="registry.iic.jku.at:5000/iic-osic-tools:tool-snp2le-latest"
 ARG TOOL_IMAGE_SPICEBIND="registry.iic.jku.at:5000/iic-osic-tools:tool-spicebind-latest"
 ARG TOOL_IMAGE_SPIKE="registry.iic.jku.at:5000/iic-osic-tools:tool-spike-latest"
 ARG TOOL_IMAGE_SURELOG="registry.iic.jku.at:5000/iic-osic-tools:tool-surelog-latest"
@@ -92,6 +93,7 @@ FROM ${TOOL_IMAGE_RFTOOLKIT} AS rftoolkit
 FROM ${TOOL_IMAGE_RISCV_GNU_TOOLCHAIN} AS riscv-gnu-toolchain
 FROM ${TOOL_IMAGE_SLANG} AS slang
 FROM ${TOOL_IMAGE_SLANG_YOSYS_PLUGIN} AS slang-yosys-plugin
+FROM ${TOOL_IMAGE_SNP2LE} AS snp2le
 FROM ${TOOL_IMAGE_SPICEBIND} AS spicebind
 FROM ${TOOL_IMAGE_SPIKE} AS spike
 FROM ${TOOL_IMAGE_SURELOG} AS surelog
@@ -152,6 +154,7 @@ COPY --link --from=rftoolkit                    ${TOOLS}/rftoolkit              
 COPY --link --from=riscv-gnu-toolchain          ${TOOLS}/riscv-gnu-toolchain    ${TOOLS}/riscv-gnu-toolchain/
 COPY --link --from=slang                        ${TOOLS}/slang                  ${TOOLS}/slang/
 COPY --link --from=slang-yosys-plugin           ${TOOLS}/slang-yosys-plugin     ${TOOLS}/slang-yosys-plugin/
+COPY --link --from=snp2le                       ${TOOLS}/snp2le                 ${TOOLS}/snp2le/
 COPY --link --from=spicebind                    ${TOOLS}/spicebind              ${TOOLS}/spicebind/
 COPY --link --from=spike                        ${TOOLS}/spike                  ${TOOLS}/spike/
 COPY --link --from=surelog                      ${TOOLS}/surelog                ${TOOLS}/surelog/

--- a/_build/images/iic-osic-tools/skel/usr/share/applications/snp2le.desktop
+++ b/_build/images/iic-osic-tools/skel/usr/share/applications/snp2le.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=snp2le
+GenericName=S-parameter to Lumped-Element Netlist Converter
+Comment=Convert Touchstone .sNp S-parameters to SPICE/Spectre lumped-element netlists
+Exec=snp2le
+Type=Application
+Icon=/foss/tools/snp2le/converter/gui/assets/snp2le.ico
+Terminal=false
+Categories=Development;Electronics;

--- a/_build/images/snp2le/Dockerfile
+++ b/_build/images/snp2le/Dockerfile
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2026 Harald Pretl and Georg Zachl
+# Johannes Kepler University, Department for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#######################################################################
+# Install snp2le (S-parameter to lumped-element netlist converter)
+#######################################################################
+ARG BASE_IMAGE_BUILD=registry.iic.jku.at:5000/iic-osic-tools:base-dev
+FROM ${BASE_IMAGE_BUILD} AS snp2le
+ARG SNP2LE_REPO_URL="https://github.com/iic-jku/snp2le.git"
+# ToDo: update
+ARG SNP2LE_REPO_COMMIT="e0af3048e0051f582740013908981f6e9ffaf21a"
+ARG SNP2LE_NAME="snp2le"
+RUN --mount=type=bind,source=images/snp2le,target=/images/snp2le \
+    bash /images/snp2le/scripts/install.sh

--- a/_build/images/snp2le/scripts/install.sh
+++ b/_build/images/snp2le/scripts/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 Harald Pretl and Georg Zachl
+# Johannes Kepler University, Department for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# snp2le is a pure-Python tool (PySide6 GUI + CLI). All Python dependencies
+# (PySide6, scikit-rf, schemdraw, matplotlib, numpy, scipy) are already
+# provided by the base image, so we only need to fetch the sources and expose
+# launcher wrappers on PATH.
+
+mkdir -p "$TOOLS" && cd "$TOOLS"
+git clone --filter=blob:none "${SNP2LE_REPO_URL}" "${SNP2LE_NAME}"
+cd "${SNP2LE_NAME}" || exit 1
+git checkout "${SNP2LE_REPO_COMMIT}"
+
+# Create wrappers in bin/ so install_links.sh symlinks them onto PATH.
+mkdir -p "${TOOLS}/${SNP2LE_NAME}/bin"
+
+# The Python application lives in the converter/ subdirectory and uses bare
+# imports (`from gui... import`, `from core... import`), so the wrappers must
+# run from converter/ for the package root to resolve.
+
+# GUI launcher (PySide6).
+# shellcheck disable=SC2016
+echo '#!/bin/bash
+cd "${TOOLS}/snp2le/converter" && exec python3 app.py "$@"' > "${TOOLS}/${SNP2LE_NAME}/bin/snp2le"
+chmod +x "${TOOLS}/${SNP2LE_NAME}/bin/snp2le"
+
+# Command-line interface (for Makefiles / batch conversion).
+# shellcheck disable=SC2016
+echo '#!/bin/bash
+cd "${TOOLS}/snp2le/converter" && exec python3 cli.py "$@"' > "${TOOLS}/${SNP2LE_NAME}/bin/snp2le-cli"
+chmod +x "${TOOLS}/${SNP2LE_NAME}/bin/snp2le-cli"
+
+echo "${SNP2LE_NAME} ${SNP2LE_REPO_COMMIT}" > "${TOOLS}/${SNP2LE_NAME}/SOURCES"

--- a/_build/tool_metadata.yml
+++ b/_build/tool_metadata.yml
@@ -106,6 +106,9 @@
 - name: slang-yosys-plugin
   repo: https://github.com/povik/yosys-slang.git
   commit: cf20b1ba0d2c9df0508f927930a87565e7e0d220
+- name: snp2le
+  repo: https://github.com/iic-jku/snp2le.git
+  commit: e0af3048e0051f582740013908981f6e9ffaf21a # ToDo: update
 - name: spicebind
   repo: https://github.com/themperek/spicebind.git
   commit: a63974c81391c10c0700244c32c0b7733ae711b1


### PR DESCRIPTION
I am currently building a promising [`snp2le`](https://github.com/iic-jku/snp2le) tool. A PySide6 interactive GUI and CLI-based S-parameter Touchstone file (.snp) to lumped element netlist (SPICE, Spectre) converter.
This PR should add it to the IIC-OSIC-TOOLS image build flow. All Python dependencies are already installed. 
The tool is in the final stage for its first release. Hence, this PR is still a draft. Maybe we should also discuss whether we want this tool in the container. I would say yes.