### PR TITLE
build: install_eda: Add gdsfill (Rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Below is a list of the current tools/PDKs already installed and ready to use:
 - [gds2palace](https://github.com/VolkerMuehlhaus/setupEM)/`setupEM` setup tools for `palace` EM simulation
 - [gds3d](https://github.com/trilomix/GDS3D) a 3D viewer for GDS files
 - [gdsfactory](https://github.com/gdsfactory/gdsfactory) Python library for GDS generation
-- [gdsfill](https://github.com/aesc-silicon/gdsfill) Python tool for inserting dummy metal fill into semiconductor layouts
+- [gdsfill](https://github.com/aesc-silicon/gdsfill) Rust tool for inserting dummy metal fill into semiconductor layouts
 - [gdspy](https://github.com/heitzmann/gdspy) Python module for the creation and manipulation of GDS files
 - [gf180mcu](https://github.com/google/gf180mcu-pdk) GlobalFoundries 180 nm CMOS PDK
 - [ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin) VHDL-plugin for `yosys`

--- a/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
+++ b/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
@@ -54,6 +54,20 @@ if [ "$(uname -m)" = "x86_64" ]; then
 		setupEM==0.1.22
 fi
 
+echo "[INFO] Install EDA packages via Cargo"
+
+export RUSTUP_HOME=/tmp/rustup
+export CARGO_HOME=/tmp/cargo
+export PATH=$CARGO_HOME/bin:$PATH
+rustup default stable
+
+cargo install \
+	gdsfill --version 0.1.7 \
+	--root "${TOOLS}"
+
+# Drop the Rust toolchain and registry cache so they don't bloat the image.
+rm -rf "$RUSTUP_HOME" "$CARGO_HOME"
+
 echo "[INFO] Installing CharLib"
 python3 -m venv /foss/tools/charlib
 /foss/tools/charlib/bin/pip install --no-cache-dir \


### PR DESCRIPTION
Add the rust-based version of gdsfill, which is still experimental but will replace the Python-based implementation later.

The Python-based version will be removed later and should be kept as backup. Right now, the Rust version is discoverable first via PATH.