### PR TITLE
added `termcolor` to base image pip packages

### DIFF
--- a/_build/images/base/scripts/70_install_from_pip.sh
+++ b/_build/images/base/scripts/70_install_from_pip.sh
@@ -48,6 +48,7 @@ pip3 install $PIP_FLAGS \
 	simanneal \
 	svgutils \
 	sympy \
+	termcolor \
 	tomli \
 	torch_geometric \
 	ziamath


### PR DESCRIPTION
### What
Adds `termcolor` to the pip install list in `_build/images/base/scripts/70_install_from_pip.sh`.

### Why
`termcolor` is a required Python dependency for the IHP-Open-PDK (see [requirements.txt](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/requirements.txt)) KLayout LVS test flow calls `create_cell_testcases.py`, which does `from termcolor import cprint`. Without the package, the script aborts with `ModuleNotFoundError: No module named 'termcolor'`.

It is currently the only entry in IHP-Open-PDK's `requirements.txt` that is not already provided by the image. All the others (pandas, gdstk, tqdm, docopt, pyyaml, klayout, tkinter, flake8) are already available, either listed directly or pulled in as transitive dependencies. `termcolor` has no parent package that would pull it in, so it needs to be added explicitly.

### Effect
Scripts that import `termcolor` run out of the box, with no manual `pip install` step needed inside the container.

### State
Ready for merging.
