### PR TITLE
updated `iic-osic-tools-setup.sh` to add Xschem symbols for VACASK analyses

### DIFF
--- a/_build/images/base/skel/etc/profile.d/iic-osic-tools-setup.sh
+++ b/_build/images/base/skel/etc/profile.d/iic-osic-tools-setup.sh
@@ -136,3 +136,18 @@ if [ -n "${DESIGNS}" ] && [ -f "$DESIGNS/.designinit" ]; then
     # shellcheck source=/dev/null
     source "$DESIGNS/.designinit"
 fi
+
+# Always make the (PDK-independent) VACASK analyses symbols available in the xschem
+# symbol browser, from any working directory. This runs after .designinit so it adds
+# to any XSCHEM_USER_LIBRARY_PATH the user set there instead of overwriting it. The
+# analyses path is prepended so it sorts ahead of the user's project-specific paths.
+# The PDK xschemrc appends XSCHEM_USER_LIBRARY_PATH to XSCHEM_LIBRARY_PATH, so this
+# also works in project folders that ship their own xschemrc. The case statement skips
+# the change when the path is already present, so a re-sourced login shell does not
+# add a duplicate.
+_iic_analyses_lib="${TOOLS}/xschem/share/doc/xschem/analyses"
+case ":${XSCHEM_USER_LIBRARY_PATH}:" in
+    *":${_iic_analyses_lib}:"*) ;;
+    *) export XSCHEM_USER_LIBRARY_PATH="${_iic_analyses_lib}${XSCHEM_USER_LIBRARY_PATH:+:${XSCHEM_USER_LIBRARY_PATH}}" ;;
+esac
+unset _iic_analyses_lib

--- a/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
+++ b/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
@@ -1,5 +1,5 @@
+# Append the VACASK analyses symbols so they show up in the library manager
+append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses
+
 # Source the PDK xschemrc file
 source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
-
-# Append the VACASK analyses symbols so they show up in the library manager (append, do not override, the paths set by the PDK xschemrc above)
-append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses

--- a/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
+++ b/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
@@ -1,5 +1,2 @@
 # Source the PDK xschemrc file
 source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
-
-# Append the VACASK analyses symbols so they show up in the library manager
-append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses

--- a/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
+++ b/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
@@ -1,2 +1,5 @@
 # Source the PDK xschemrc file
 source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
+
+# Append the VACASK analyses symbols so they show up in the library manager (append, do not override, the paths set by the PDK xschemrc above)
+append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses

--- a/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
+++ b/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
@@ -1,5 +1,5 @@
-# Append the VACASK analyses symbols so they show up in the library manager
-append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses
-
 # Source the PDK xschemrc file
 source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
+
+# Append the VACASK analyses symbols so they show up in the library manager
+append XSCHEM_LIBRARY_PATH :$env(TOOLS)/xschem/share/doc/xschem/analyses


### PR DESCRIPTION
### Motivation

@arpadbuermen provided Xschem symbols for VACASK analyses. They are based on Qucs-style symbols and should simplify the transition for Qucs users to Xschem. And of course, they are in general quite handy.
Unfortunately, they are pretty hidden in Xschem and are located at `xschem/share/doc/xschem/analyses`.

### Fix

Set `XSCHEM_USER_LIBRARY_PATH` in the container profile in the `iic-osic-tools-setup.sh` file. The PDK `xschemrc` appends this variable to `XSCHEM_LIBRARY_PATH`, so the analyses symbols are picked up no matter which xschemrc wins, including project folders with their own `xschemrc`.
The line runs after sourcing `.designinit`, so it preserves any path the user set there, and it _prepends_ the analyses path so it sorts ahead of project-specific paths. It is idempotent, so a re-sourced login shell does not create duplicates.

With this PR, the "Insert Symbol" window in Xschem looks like this:

<img width="870" height="543" alt="image" src="https://github.com/user-attachments/assets/6072003c-7adb-4d3a-bfe1-4d4918f4afc7" />

### Notes

This is a base-image change, so it requires an image rebuild to take effect.

### Questions

@hpretl @StefanSchippers, what do you think about this solution? Might it be actually better to already add this path to the **Xschem** `xschemrc` file? Thanks!
