### PR TITLE
added regression test of SPARX with ihp-sg13g2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ IIC-OSIC-TOOLS is a comprehensive Docker/Podman-based container distribution for
 
 **Key directories:**
 - `_build/`: Multi-stage Docker build system with tool images and build orchestration
-- `_tests/`: Regression test suite (20 tests covering PDKs, tools, and workflows)
+- `_tests/`: Regression test suite (22 tests covering PDKs, tools, and workflows)
 - Root scripts: Container startup scripts for VNC, X11, Jupyter, and shell modes
 
 ## Architecture & Build System

--- a/_tests/22/test_sparx_sg13g2.sh
+++ b/_tests/22/test_sparx_sg13g2.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Simon Dorrer
+# Johannes Kepler University, Department for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression test based on the SPARX six-port receiver of
+# <https://github.com/iic-jku/SG13CMOS_SPARX>.
+#
+# It clones the repository and runs its `make regression` target, which builds
+# the layout (gdsfactory), verifies it (magic), runs an EM simulation (palace),
+# converts the S-parameters to a lumped-element model (snp2le) and simulates
+# the result with ngspice and VACASK (xschem).
+
+if [ -z "${RAND}" ]; then
+    RAND=$(hexdump -e '/1 "%02x"' -n4 < /dev/urandom)
+fi
+
+DEBUG=${DEBUG:-0}
+
+TMP=/foss/designs/runs/${RAND}/22
+LOG=$TMP/sparx_sg13g2.log
+REPO=SG13CMOS_SPARX
+
+mkdir -p "$TMP"
+cd "$TMP" || exit 1
+
+# Clone the main branch of the SPARX repository
+[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (main branch) ..."
+if ! git clone --branch main \
+        https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
+    echo "[ERROR] Test <SPARX with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
+    exit 1
+fi
+cd "$REPO" || exit 1
+
+# Allow git to operate on this repo even if the dir owner differs from the
+# container user (avoids "detected dubious ownership")
+git config --global --add safe.directory "$TMP/$REPO"
+
+# Switch to the ihp-sg13g2 PDK (sets PDK and PDK_ROOT, loads the OSDI models)
+[ "$DEBUG" = 1 ] && echo "[INFO] Switching to the ihp-sg13g2 PDK ..."
+# shellcheck source=/dev/null
+source sak-pdk-script.sh ihp-sg13g2 > /dev/null
+
+# Run the regression target and check the result
+[ "$DEBUG" = 1 ] && echo "[INFO] Running 'make regression' (output is logged to $LOG) ..."
+if make regression >> "$LOG" 2>&1; then
+    echo "[INFO] Test <SPARX with ihp-sg13g2> passed."
+    exit 0
+else
+    echo "[ERROR] Test <SPARX with ihp-sg13g2> FAILED! Check the log file $LOG for details."
+    exit 1
+fi

--- a/_tests/TESTS.md
+++ b/_tests/TESTS.md
@@ -23,3 +23,4 @@
 | 19       | LibreLane with ihp-sg13cmos5l                                                                                                   |
 | 20       | [AMS chip template](https://github.com/iic-jku/ihp-sg13g2-ams-chip-template) with ihp-sg13g2                                    |
 | 21       | [analog circuit design](https://github.com/iic-jku/analog-circuit-design) xschem/ngspice simulation testbenches with ihp-sg13g2 |
+| 22       | [SPARX](https://github.com/iic-jku/SG13CMOS_SPARX) six-port receiver with ihp-sg13g2                                            |


### PR DESCRIPTION
I implemented a regression test of [SPARX](https://github.com/iic-jku/SG13CMOS_SPARX) with ihp-sg13g2 for the IIC-OSIC-TOOLS. I added test 22. The script is called `test_sparx_sg13g2.sh`. I updated `TESTS.md` and `copilot-instructions.md` accordingly.