### PR TITLE
Patch sky130 pcells for current gdsfactory, drop gdsfactory8 venv

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -32,11 +32,11 @@ export LIBGL_ALWAYS_INDIRECT=0
 
 Some pcell libraries were developed for older `gdsfactory` versions:
 
-- Skywater `sky130A`/`sky130B`: pcells require `gdsfactory==8.0.0` (the version that introduced the KLayout/kdb backend with kfactory 0.17.x APIs). System `gdsfactory9` is incompatible.
+- Skywater `sky130A`/`sky130B`: pcells were written against the `gdsfactory` 8.x APIs and private kfactory 0.17.x internals (`_get_default_kcl`, `_kdb_cell`, `Component.add_array`, implicit generic-PDK activation), which later `gdsfactory`/kfactory versions removed.
 - Global Foundries `gf180mcuC`/`gf180mcuD`: pcells work with `gdsfactory==9.20.6`. The image pins the system `gdsfactory` to this version.
 
 The image addresses these automatically (issue <https://github.com/iic-jku/IIC-OSIC-TOOLS/issues/162>):
-- A `gdsfactory==8.0.0` virtual environment is installed at `/foss/tools/klayout_gdsfactory8/`. When `sak-pdk sky130A` (or `sky130B`) is run, `KLAYOUT_PYTHONPATH` is set to this venv's `site-packages`. KLayout prepends `KLAYOUT_PYTHONPATH` to its embedded Python `sys.path`, so the sky130 pcell libraries load correctly.
+- The `sky130A`/`sky130B` pcells are patched at PDK-install time (kfactory >= 1.x API compatibility, an `add_array` shim, and explicit generic-PDK activation), so they work with the current system `gdsfactory` and need no dedicated virtual environment.
 - A `gdsfactory==9.20.6` virtual environment is installed at `/foss/tools/klayout_gdsfactory9/`. When `sak-pdk gf180mcuC` (or `gf180mcuD`) is run, `KLAYOUT_PYTHONPATH` is set to this venv's `site-packages`. KLayout prepends `KLAYOUT_PYTHONPATH` to its embedded Python `sys.path`, so the sky130 pcell libraries load correctly.
 
 ### The OpenROAD Flow Scripts (ORFS)

--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pdk-script.sh
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pdk-script.sh
@@ -82,13 +82,9 @@ else
 		esac
 	fi
 
-	# sky130A/B pcell libraries require gdsfactory==8.0.0 (KLayout/kdb backend).
 	# gf180mcuC/D pcell libraries require gdsfactory==9.20.6.
 	# Point KLAYOUT_PYTHONPATH at the dedicated venv so KLayout uses it for pcells.
 	case "$1" in
-		sky130A|sky130B)
-			_KLAYOUT_VENV="/foss/tools/klayout_gdsfactory8"
-			;;
 		gf180mcuC|gf180mcuD)
 			_KLAYOUT_VENV="/foss/tools/klayout_gdsfactory9"
 			;;

--- a/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
+++ b/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
@@ -98,11 +98,7 @@ gem install \
 	rggen-vhdl:0.13.0 \
 	rggen-veryl:0.8.0
 
-# Create dedicated gdsfactory venvs for KLayout pcell compatibility.
-
-echo "[INFO] Creating gdsfactory8 venv for KLayout sky130A/B pcell compatibility"
-python3 -m venv /foss/tools/klayout_gdsfactory8
-/foss/tools/klayout_gdsfactory8/bin/pip install --no-cache-dir "gdsfactory==8.0.0"
+# Create dedicated gdsfactory venv for KLayout pcell compatibility.
 
 echo "[INFO] Creating gdsfactory9 venv for KLayout gf180mcuC/D pcell compatibility"
 python3 -m venv /foss/tools/klayout_gdsfactory9

--- a/_build/images/open_pdks/scripts/install_ciel.sh
+++ b/_build/images/open_pdks/scripts/install_ciel.sh
@@ -47,11 +47,84 @@ if [ -d "$PDK_ROOT/sky130A" ]; then
 	# shellcheck disable=SC2016
 	sed -i '/<original-base-path>/c\ <original-base-path>$PDK_ROOT/$PDK/libs.tech/klayout</original-base-path>' "$PDK_ROOT/sky130A/libs.tech/klayout/tech/sky130A.lyt"
 
-	# Fix gdsfactory boolean operation "A-B" -> "-" for gdsfactory 8.x compatibility
-	# (gdsfactory 8.x does not support the "A-B" operation string; use "-" instead)
+	# Patch the pcells for compatibility with gdsfactory >= 8.x / kfactory >= 1.x
+	# so they work with the current system gdsfactory (no dedicated venv needed).
 	if [ -d "$PDK_ROOT/sky130A/libs.tech/klayout/python/cells" ]; then
+		# gdsfactory >= 8 does not support the "A-B" boolean operation string
+		# anymore; use "-" instead. Some occurrences are spelled 'operation= "A-B"'.
 		find "$PDK_ROOT/sky130A/libs.tech/klayout/python/cells" -name "*.py" \
-			-exec sed -i 's/operation="A-B"/operation="-"/g' {} \;
+			-exec sed -i 's/operation= *"A-B"/operation="-"/g' {} \;
+
+		# cells/pdk.py was written against kfactory 0.x internals: the private
+		# _get_default_kcl() and KCell._kdb_cell were removed in kfactory >= 1.x,
+		# and kfactory >= 1.x locks cells produced by cached cell functions, which
+		# breaks the scale_and_snap grid snapping in take_component().
+		python3 - "$PDK_ROOT/sky130A/libs.tech/klayout/python/cells/pdk.py" <<'PYEOF'
+import sys
+
+path = sys.argv[1]
+with open(path) as f:
+    src = f.read()
+
+old = "  kf.kcell._get_default_kcl().clear()\n"
+new = """  # kfactory >= 1.x removed the private _get_default_kcl(); the default
+  # layout is available as kf.kcl there.
+  try:
+    kf.kcell._get_default_kcl().clear()
+  except AttributeError:
+    kf.kcl.clear()
+"""
+assert old in src, "pdk.py: _get_default_kcl pattern not found"
+src = src.replace(old, new)
+
+old = "  source_cell = c._kdb_cell\n"
+new = """  # kfactory >= 1.x exposes the native cell as the public kdb_cell property.
+  source_cell = getattr(c, "kdb_cell", None)
+  if source_cell is None:
+    source_cell = c._kdb_cell
+
+  # kfactory >= 1.x locks cells produced by cached cell functions; unlock
+  # them so scale_and_snap below may modify the cell tree.
+  for cell in source_cell.layout().each_cell():
+    if cell.locked:
+      cell.locked = False
+"""
+assert old in src, "pdk.py: _kdb_cell pattern not found"
+src = src.replace(old, new)
+
+with open(path, "w") as f:
+    f.write(src)
+PYEOF
+
+		# gdsfactory 9 removed Component.add_array, and gdsfactory >= 9.29 no
+		# longer auto-activates the generic PDK (the CONF.pdk default changed
+		# from "generic" to None), which the drawing code relies on for layer
+		# resolution. Both shims are no-ops on older gdsfactory versions.
+		cat >> "$PDK_ROOT/sky130A/libs.tech/klayout/python/cells/__init__.py" <<'PYEOF'
+
+
+def _gf9_compat():
+    from typing import Optional
+
+    import gdsfactory as gf
+
+    def _add_array(self, component, columns=2, rows=2,
+                   spacing=(100, 100), alias: Optional[str] = None):
+        return self.add_ref(component=component, name=alias,
+                            columns=columns, rows=rows,
+                            column_pitch=spacing[0], row_pitch=spacing[1])
+
+    if not hasattr(gf.Component, "add_array"):
+        gf.Component.add_array = _add_array
+
+    try:
+        gf.get_active_pdk()
+    except ValueError:
+        gf.gpdk.PDK.activate()
+
+
+_gf9_compat()
+PYEOF
 	fi
 fi
 


### PR DESCRIPTION
## What changed

The sky130A/B KLayout pcells (Mabrains library shipped in open_pdks) so far required a dedicated `gdsfactory==8.0.0` virtual environment (`/foss/tools/klayout_gdsfactory8`, ~755 MB uncompressed), wired up via `KLAYOUT_PYTHONPATH` in `sak-pdk`. This PR patches the pcells at PDK-install time instead, so they run on the current **system** gdsfactory, and removes the venv.

- **`install_ciel.sh`** (sky130A section):
  - `cells/pdk.py`: fall back to `kf.kcl` where the private `_get_default_kcl()` was removed (kfactory ≥ 1.x), use the public `kdb_cell` property instead of `_kdb_cell`, and unlock kfactory-locked cells before the `scale_and_snap` grid snap. Applied via a `python3` heredoc that asserts on the expected patterns, so an upstream change fails the build instead of silently shipping broken pcells.
  - `cells/__init__.py`: append a `Component.add_array` compatibility shim (removed in gdsfactory 9) and explicit generic-PDK activation (gdsfactory ≥ 9.29 no longer auto-activates it). Both are no-ops on older gdsfactory versions.
  - Broaden the existing boolean-operation sed to `operation= *"A-B"` — the spaced variants in `draw_diode.py`/`draw_fet.py` were missed so far, which made `p_diode` (default parameters) and the fet **"guard ring"** bulk option produce empty cells even with the gdsfactory 8 venv (pre-existing bug, fixed by this).
- **`install_eda.sh`**: drop the `klayout_gdsfactory8` venv (−755 MB image size).
- **`sak-pdk-script.sh`**: remove the sky130A/B `KLAYOUT_PYTHONPATH` case.
- **`KNOWN_ISSUES.md`**: update the pcell section accordingly.

## Verification

Inside `hpretl/iic-osic-tools:2026.06` with the real `klayout -b` (KLayout 0.30.9): the exact sky130A block from the edited `install_ciel.sh` was applied to the shipped `/foss/pdks/sky130A` tree, then all 18 registered pcells plus `nfet`/`pfet` guard-ring and bulk-tie variants were instantiated via `add_pcell_variant`:

| configuration | result | GDS vs gdsfactory-8 baseline |
|---|---|---|
| system gdsfactory 9.44.0 (kfactory 2.5.3), no `KLAYOUT_PYTHONPATH` | 21/21 OK | 0/21 differ (flat per-layer XOR) |
| gdsfactory 9.46.0 (kfactory 3.0.2) | 21/21 OK | 0/21 differ |
| gdsfactory 8.0.0 venv on the patched tree (backward compat) | 21/21 OK | — |

`sak-pdk sky130A` now leaves `KLAYOUT_PYTHONPATH` unset; `sak-pdk gf180mcuD` still points at the gdsfactory9 venv.

## Notes for reviewers

- The gf180mcu `klayout_gdsfactory9` venv is intentionally untouched here — its removal lives on `remove-gf180mcu-gdsfactory-pin`. Expect a small textual merge conflict in `install_eda.sh`/`sak-pdk-script.sh` between the two branches (adjacent line removals).
- Possible follow-up: upstream the `pdk.py`/`__init__.py` fixes to the Mabrains sky130 pcell repo / open_pdks so the install-time surgery can eventually be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)