### PR TITLE
Add Podman support across start/install scripts

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -59,18 +59,15 @@ As of image `2025.01` Surfer has been added. Surfer is known to crash on quite a
 
 ### Podman Compatibility
 
-The IIC-OSIC-Tools container can be run using Podman instead of Docker (with the Podman Docker compatible CLI), but it introduces some issues:
+The IIC-OSIC-Tools container can be run using Podman instead of Docker. The start scripts auto-detect the installed engine (override with `CONTAINER_ENGINE=podman`), and in rootless mode they automatically add `--userns=keep-id` and default the VNC webserver port to `8080`, see [Section 5.1 of the README](README.md#51-podman).
 
-- By default, Podman mounts all bind-mounts/volumes as root, even though the `UID` inside the container is != 0, which creates some problems when accessing files inside the container. To work around this issue, we suggest the following procedure:
-- Edit the desired start script and find/replace all occurrences of `:rw` with `:U,rw`. Then Podman will mount all listed directories with the given `UID` inside the container.
-
-For rootless Podman operation (which resolves X11/Wayland socket access issues), please refer to [Section 5.1 of the README](README.md#51-podman) and use `--userns=keep-id`.
+If you run *rootful* Podman with a non-root `CONTAINER_USER`, bind-mounts are mounted as root, which creates problems when accessing files inside the container. In this case, either switch to rootless Podman (recommended), or edit the desired start script and find/replace all occurrences of `:rw` with `:U,rw`, so Podman will chown the mounted directories to the given `UID` inside the container.
 
 ### Docker Rootless Mode
 
 Running Docker in rootless mode with X11/Wayland forwarding (`start_x.sh`) is not fully supported. The X11 and Wayland sockets are not accessible from the container due to UID/GID mismatches in the user namespace. There is no straightforward fix for Docker rootless mode.
 
-**Workaround:** Switch to [Podman](https://podman.io/) in rootless mode with `--userns=keep-id` (see [Section 5.1 of the README](README.md#51-podman)). The `start_x.sh` script automatically detects Podman rootless mode and prints the required command.
+**Workaround:** Switch to [Podman](https://podman.io/) in rootless mode (see [Section 5.1 of the README](README.md#51-podman)). The start scripts automatically detect Podman rootless mode and add `--userns=keep-id`.
 
 ### Palace EM-Setup
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ It supports multiple *modes of operation*:
 
 If you just want to get going on a fresh machine, the repository ships with an
 interactive installer that takes care of the prerequisites (Git, Docker /
-Docker Desktop, WSL2 on Windows, XQuartz on macOS) and clones this repository
-for you. Every action is gated behind a `[y/N]` confirmation prompt.
+Docker Desktop or Podman, WSL2 on Windows, XQuartz on macOS) and clones this
+repository for you. Every action is gated behind a `[y/N]` confirmation prompt.
 
 **Linux and macOS** (Bash, `curl` required):
 
@@ -297,9 +297,11 @@ You can now access the Desktop Environment through your browser ([http://localho
 Both scripts will use default settings, which you can tweak by settings shell variables (`VARIABLE=default` is shown):
 
 - `DRY_RUN` (unset by default); if set to any value (also `0`, `false`, etc.), the start scripts print all executed commands instead of running. Useful for debugging/testing or just creating "template commands" for unique setups.
+- `CONTAINER_ENGINE` (auto-detected) selects the container engine CLI. By default, `docker` is used if installed, otherwise `podman`. Set it explicitly (e.g. `CONTAINER_ENGINE=podman`) if both engines are installed and you want to override the default.
 - `DESIGNS=$HOME/eda/designs` (`DESIGNS=%USERPROFILE%\eda\designs` for `.bat`) sets the directory that holds your design files. This directory is mounted into the container on `/foss/designs`.
-- `WEBSERVER_PORT=80` sets the port on which the Docker daemon will map the webserver port of the container to be reachable from localhost and the outside world. `0` disables the mapping.
+- `WEBSERVER_PORT=80` sets the port on which the Docker daemon will map the webserver port of the container to be reachable from localhost and the outside world. `0` disables the mapping. With rootless Podman (which cannot bind ports below 1024) the default is `8080`.
 - `VNC_PORT=5901` sets the port on which the Docker daemon will map the VNC server port of the container to be reachable from localhost and the outside world. This is only required to access the UI with a different VNC client. `0` disabled the mapping.
+- `DOCKER_REGISTRY="docker.io"` registry prefix used to fully qualify the image name (required for Podman, which does not resolve short names non-interactively). Set it to `""` to use unqualified names.
 - `DOCKER_USER="hpretl"` username for the Docker Hub repository from which the images are pulled. Usually, no change is required.
 - `DOCKER_IMAGE="iic-osic-tools"` Docker Hub image name to pull. Usually, no change is required.
 - `DOCKER_TAG="latest"` Docker Hub image tag. By default, it pulls the latest version; this might be handy to change if you want to match a specific version set.
@@ -336,7 +338,9 @@ or
 The following environment variables are used for configuration:
 
 - `DRY_RUN` (unset by default), if set to any value (also `0`, `false`, etc.), makes the start scripts print all executed commands instead of running. Useful for debugging/testing or just creating "template commands" for unique setups.
+- `CONTAINER_ENGINE` (auto-detected) selects the container engine CLI. By default, `docker` is used if installed, otherwise `podman`. Set it explicitly (e.g. `CONTAINER_ENGINE=podman`) if both engines are installed and you want to override the default.
 - `DESIGNS=$HOME/eda/designs` (`DESIGNS=%USERPROFILE%\eda\designs` for `.bat`) sets the directory that holds your design files. This directory is mounted into the container on `/foss/designs`.
+- `DOCKER_REGISTRY="docker.io"` registry prefix used to fully qualify the image name (required for Podman, which does not resolve short names non-interactively). Set it to `""` to use unqualified names.
 - `DOCKER_USER="hpretl"` username for the Docker Hub repository from which the images are pulled. Usually, no change is required.
 - `DOCKER_IMAGE="iic-osic-tools"` Docker Hub image name to pull. Usually, no change is required.
 - `DOCKER_TAG="latest"` Docker Hub image tag. By default, it pulls the latest version; this might be handy to change if you want to match a specific Version set.
@@ -432,15 +436,14 @@ For container experts, there is also support for other container engines and add
 
 ### 5.1 Podman
 
-[Podman](https://podman.io/) is a demonless, OCI compatible container engine, that supports rootless containers to contain privileges inside the container. Normal root containers are supported out of the box, the Docker-compatible CLI can be used with the start scripts without modification. Using rootless mode, we suggest using the user-namespace mode "keep-id". In this case, the host-user, launching the container, is copied to the container (same UID, GID, user and group name), preventing access issues between the container and mounted directories from the host. This can be achieved by using:
+[Podman](https://podman.io/) is a demonless, OCI compatible container engine, that supports rootless containers to contain privileges inside the container. Podman is supported as a co-equal runtime by all start scripts: they auto-detect the installed engine (preferring `docker` if both are present; override with `CONTAINER_ENGINE=podman`), so no `podman-docker` compatibility alias and no script modification is needed. The interactive installers (`install.sh`/`install.ps1`) can install Podman instead of Docker.
 
-`DOCKER_EXTRA_PARAMS="--userns=keep-id" ./start_<mode>.sh`
+In Podman rootless mode, the start scripts automatically handle the two classic pitfalls:
 
-It should be noted, that the rootless mode can't bind to ports below 1024. This means, for the VNC-mode, a different webserver port has to be selected, e.g.:
+- They add `--userns=keep-id` (unless a `--userns` option is already given via `DOCKER_EXTRA_PARAMS`), so the host user launching the container is mapped to the same UID/GID inside the container, preventing access issues between the container and mounted directories from the host.
+- Since rootless mode cannot bind ports below 1024, `start_vnc.sh` defaults the webserver port to `8080` instead of `80` (an explicitly set `WEBSERVER_PORT` below 1024 produces a warning).
 
-`WEBSERVER_PORT=8080 DOCKER_EXTRA_PARAMS="--userns=keep-id" ./start_<mode>.sh`
-
-The `start_x.sh` script automatically detects Podman rootless mode and prints the above suggestion if `--userns=keep-id` has not already been set.
+So in most cases, simply running `./start_<mode>.sh` works out of the box with rootless Podman.
 
 > **Note on Docker Rootless Mode:** Docker in rootless mode has known limitations with X11/Wayland socket forwarding due to UID/GID mismatches between the host and container. There is no straightforward fix for Docker rootless mode, and we therefore recommend using Podman with `--userns=keep-id` as the preferred solution for rootless container operation.
 

--- a/README.md
+++ b/README.md
@@ -438,12 +438,19 @@ For container experts, there is also support for other container engines and add
 
 [Podman](https://podman.io/) is a demonless, OCI compatible container engine, that supports rootless containers to contain privileges inside the container. Podman is supported as a co-equal runtime by all start scripts: they auto-detect the installed engine (preferring `docker` if both are present; override with `CONTAINER_ENGINE=podman`), so no `podman-docker` compatibility alias and no script modification is needed. The interactive installers (`install.sh`/`install.ps1`) can install Podman instead of Docker.
 
-In Podman rootless mode, the start scripts automatically handle the two classic pitfalls:
+The start scripts automatically handle the classic Podman pitfalls:
 
-- They add `--userns=keep-id` (unless a `--userns` option is already given via `DOCKER_EXTRA_PARAMS`), so the host user launching the container is mapped to the same UID/GID inside the container, preventing access issues between the container and mounted directories from the host.
-- Since rootless mode cannot bind ports below 1024, `start_vnc.sh` defaults the webserver port to `8080` instead of `80` (an explicitly set `WEBSERVER_PORT` below 1024 produces a warning).
+- In rootless mode, they add `--userns=keep-id` (unless a `--userns` option is already given via `DOCKER_EXTRA_PARAMS`), so the host user launching the container is mapped to the same UID/GID inside the container, preventing access issues between the container and mounted directories from the host.
+- Since rootless mode cannot bind host ports below 1024, `start_vnc.sh` defaults the webserver port to `8080` instead of `80` (an explicitly set `WEBSERVER_PORT` below 1024 produces a warning).
+- `start_vnc.sh` passes `--sysctl net.ipv4.ip_unprivileged_port_start=0` to Podman (rootful and rootless). Docker sets this namespaced sysctl in every container by default, Podman does not — without it, the noVNC webserver (which runs as a non-root user) cannot bind port 80 *inside* the container and the VNC mode fails.
 
-So in most cases, simply running `./start_<mode>.sh` works out of the box with rootless Podman.
+So in most cases, simply running `./start_<mode>.sh` works out of the box with Podman.
+
+By default, the container uses [nss_wrapper](https://cwrap.org/nss_wrapper.html) to fake a passwd/group entry (`designer`) for the arbitrary UID/GID the container is started with. With Podman and `--userns=keep-id` a real passwd entry for the current user already exists inside the container, so the wrapper can optionally be disabled by setting the container environment variable `IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER` (any non-empty value):
+
+`DOCKER_EXTRA_PARAMS="-e IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER=1" ./start_<mode>.sh`
+
+As a safety net, the request is ignored (with a warning) if no passwd entry exists for the container UID, because the TigerVNC server refuses to start without one ("vncserver: I do not know who you are").
 
 > **Note on Docker Rootless Mode:** Docker in rootless mode has known limitations with X11/Wayland socket forwarding due to UID/GID mismatches between the host and container. There is no straightforward fix for Docker rootless mode, and we therefore recommend using Podman with `--userns=keep-id` as the preferred solution for rootless container operation.
 

--- a/_build/images/base/skel/dockerstartup/scripts/generate_container_user.sh
+++ b/_build/images/base/skel/dockerstartup/scripts/generate_container_user.sh
@@ -8,7 +8,20 @@ USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 [ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] USER_ID: $USER_ID, GROUP_ID: $GROUP_ID"
 
-if [[ "$USER_ID" != "0" ]]; then
+# nss_wrapper fakes a passwd/group entry ("designer") for arbitrary UIDs that
+# have no entry in /etc/passwd (docker/podman run --user UID:GID). It can be
+# disabled by setting IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER (any non-empty value),
+# e.g. when Podman with --userns=keep-id already provides a real passwd entry
+# for the current user.
+# Without any passwd entry the TigerVNC vncserver aborts ("I do not know who
+# you are"), so ignore the disable request if no entry exists for this UID.
+if [ -n "${IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER}" ] && ! getent passwd "$USER_ID" > /dev/null 2>&1; then
+    echo "[WARNING] IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER is set, but no passwd entry exists for UID ${USER_ID}; keeping nss_wrapper enabled."
+    IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER=""
+fi
+if [ -n "${IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER}" ]; then
+    [ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] nss_wrapper disabled via IIC_OSIC_TOOLS_DISABLE_NSSWRAPPER."
+elif [[ "$USER_ID" != "0" ]]; then
     if [ -z "${HOME}" ]; then
         echo "[ERROR] HOME is not set; cannot generate nss_wrapper passwd entry."
         return 1 2>/dev/null || exit 1

--- a/_build/images/base/skel/dockerstartup/scripts/ui_startup.sh
+++ b/_build/images/base/skel/dockerstartup/scripts/ui_startup.sh
@@ -10,6 +10,7 @@ help (){
 echo "
 USAGE:
 docker run -d -p 80:80 --user \$(id -u):\$(id -g) hpretl/iic-osic-tools:latest --wait
+(or use podman instead of docker; with Podman add --sysctl net.ipv4.ip_unprivileged_port_start=0 so the internal webserver can bind port 80)
 
 TAGS (See https://hub.docker.com/r/hpretl/iic-osic-tools/tags):
 latest year.month

--- a/eda_server_conf.sh
+++ b/eda_server_conf.sh
@@ -19,6 +19,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # ========================================================================
 
+# Select the container engine (Docker or Podman), can be overridden by
+# setting CONTAINER_ENGINE. Note that with Podman the "--restart always"
+# policy does not survive a host reboot unless podman-restart.service (or
+# systemd/Quadlet units) are enabled.
+if [ -z ${CONTAINER_ENGINE+z} ]; then
+    if command -v docker > /dev/null 2>&1; then
+        CONTAINER_ENGINE="docker"
+    elif command -v podman > /dev/null 2>&1; then
+        CONTAINER_ENGINE="podman"
+    else
+        echo "[ERROR] No container engine found, please install Docker or Podman!"
+        exit 1
+    fi
+fi
+export CONTAINER_ENGINE
+
 # general settings for all users
 export DOCKER_EXTRA_PARAMS="--cpus 4 --memory 8G --dns 8.8.8.8 --restart always"
 export VNC_PORT=0

--- a/eda_server_restart.sh
+++ b/eda_server_restart.sh
@@ -97,7 +97,7 @@ _spin_up_server () {
 
     [ "$DEBUG" = 1 ] && echo "[INFO] Spinning up container $CONTAINER_NAME using data directory $DESIGNS, webserver port $WEBSERVER_PORT, VNC password $VNC_PW, group-ID $CONTAINER_GROUP, container tag $DOCKER_TAG."
 
-    if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+    if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
         echo "[WARNING] Container $CONTAINER_NAME is already running, skipping!"
         return 1
     fi

--- a/eda_server_start.sh
+++ b/eda_server_start.sh
@@ -142,17 +142,17 @@ _spin_up_server () {
 
     [ "$DEBUG" = 1 ] && echo "[INFO] Spinning up container $CONTAINER_NAME using data directory $DESIGNS, webserver port $WEBSERVER_PORT, VNC password $VNC_PW, group-ID $CONTAINER_GROUP, container tag $DOCKER_TAG."
 
-    if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+    if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
         if [ "$DO_KILL" = 0 ]; then
             echo "[ERROR] Running container $CONTAINER_NAME detected without the -k option!"
             return 1
         fi
         [ "$DEBUG" = 1 ] && echo "[INFO] Container $CONTAINER_NAME running, will now stop and remove it!"
-        if ! docker stop "${CONTAINER_NAME}" > /dev/null; then
+        if ! ${CONTAINER_ENGINE} stop "${CONTAINER_NAME}" > /dev/null; then
             echo "[ERROR] Failed to stop container $CONTAINER_NAME"
             return 1
         fi
-        if ! docker rm "${CONTAINER_NAME}" > /dev/null; then
+        if ! ${CONTAINER_ENGINE} rm "${CONTAINER_NAME}" > /dev/null; then
             echo "[ERROR] Failed to remove container $CONTAINER_NAME"
             return 1
         fi

--- a/eda_server_stop.sh
+++ b/eda_server_stop.sh
@@ -64,7 +64,7 @@ shift $((OPTIND-1))
 echo "[INFO] Stopping and removing EDA containers."
 NO_INSTANCES=0
 FAILED=0
-mapfile -t CONTAINER_IDS < <(docker ps -a -q -f name="$EDA_CONTAINER_PREFIX")
+mapfile -t CONTAINER_IDS < <(${CONTAINER_ENGINE} ps -a -q -f name="$EDA_CONTAINER_PREFIX")
 
 if [ "${#CONTAINER_IDS[@]}" -eq 0 ]; then
 	echo "[INFO] No matching containers found."
@@ -74,12 +74,12 @@ fi
 
 for CONTAINER_ID in "${CONTAINER_IDS[@]}"; do
 	[ "$DEBUG" = 1 ] && echo "[INFO] Container ID $CONTAINER_ID found, now stopping and removing!"
-	if ! docker stop "$CONTAINER_ID" > /dev/null; then
+	if ! ${CONTAINER_ENGINE} stop "$CONTAINER_ID" > /dev/null; then
 		echo "[ERROR] Failed to stop container $CONTAINER_ID, skipping."
 		FAILED=$((FAILED + 1))
 		continue
 	fi
-	if ! docker rm "$CONTAINER_ID" > /dev/null; then
+	if ! ${CONTAINER_ENGINE} rm "$CONTAINER_ID" > /dev/null; then
 		echo "[ERROR] Failed to remove container $CONTAINER_ID, skipping."
 		FAILED=$((FAILED + 1))
 		continue

--- a/install.ps1
+++ b/install.ps1
@@ -31,9 +31,11 @@
 #   * winget self-check
 #   * Git for Windows                          (Git.Git)
 #   * WSL2 (kernel + default distribution)     (wsl --install)
-#   * Docker Desktop                           (Docker.DockerDesktop)
+#   * A container engine, user-selectable:
+#       - Docker Desktop                       (Docker.DockerDesktop), or
+#       - Podman                               (RedHat.Podman)
 #   * Clones the iic-osic-tools repository to a user-chosen directory
-#   * Reboots the machine (recommended after WSL / Docker install)
+#   * Reboots the machine (recommended after WSL / engine install)
 #
 # Safety:
 #   * Uses winget exclusively (signed packages from Microsoft's repository);
@@ -107,8 +109,8 @@ function Show-Disclaimer {
     Write-Host ''
     Write-Host 'This installer will make changes to your system (installing'
     Write-Host 'software via winget, enabling Windows features, registering'
-    Write-Host 'WSL2 distributions, installing Docker Desktop, and optionally'
-    Write-Host 'rebooting the machine).'
+    Write-Host 'WSL2 distributions, installing Docker Desktop or Podman, and'
+    Write-Host 'optionally rebooting the machine).'
     Write-Host ''
     Write-Host 'USE AT YOUR OWN RISK. The authors and contributors of'         -ForegroundColor Yellow
     Write-Host 'IIC-OSIC-TOOLS provide this script "AS IS", WITHOUT WARRANTY'
@@ -176,6 +178,20 @@ function Install-DockerDesktop {
     Invoke-Winget @('install','--id','Docker.DockerDesktop','-e','--source','winget',
                     '--accept-package-agreements','--accept-source-agreements')
     Write-Ok 'Docker Desktop installed. Launch it once from the Start menu after the reboot.'
+}
+
+function Install-Podman {
+    if (Test-Command podman) {
+        Write-Ok "$(podman --version) already installed."
+    } else {
+        Invoke-Winget @('install','--id','RedHat.Podman','-e','--source','winget',
+                        '--accept-package-agreements','--accept-source-agreements')
+        Write-Ok 'Podman installed.'
+    }
+    Write-Info 'Podman runs containers in a WSL2 VM (the Podman machine).'
+    Write-Info 'After the reboot, initialize and start it once from a new PowerShell:'
+    Write-Host '      podman machine init'
+    Write-Host '      podman machine start'
 }
 
 function Clone-Repo {
@@ -290,6 +306,9 @@ function Show-UsageHints {
     Write-Host '    (default: $env:USERPROFILE\eda\designs) and are mounted'
     Write-Host '    into the container at /foss/designs.'
     Write-Host ''
+    Write-Host ' The start scripts auto-detect Docker or Podman; if both are'
+    Write-Host ' installed, set CONTAINER_ENGINE=podman to override.'
+    Write-Host ''
     Write-Host ' The first launch will pull the ~4 GB image from Docker Hub.'
     Write-Host ' Reserve at least 20 GB of free disk space.'
     Write-Host '============================================================'
@@ -297,7 +316,7 @@ function Show-UsageHints {
 }
 
 function Invoke-Reboot {
-    Write-Warn2 'A reboot is strongly recommended to finalize WSL2 / Docker Desktop.'
+    Write-Warn2 'A reboot is strongly recommended to finalize WSL2 and the container engine.'
     if (-not (Ask 'Reboot now? (The system will restart in 60 seconds.)')) {
         Write-Warn2 'Please reboot manually before using iic-osic-tools.'
         return
@@ -335,9 +354,18 @@ function Main {
         throw 'Aborted by user.'
     }
 
+    Write-Info 'IIC-OSIC-TOOLS can be run with Docker Desktop (default) or Podman.'
+    Write-Info 'The start scripts auto-detect the installed engine.'
+    $script:Engine = if (Ask 'Use Podman instead of Docker Desktop as the container engine?') { 'podman' } else { 'docker' }
+    Write-Ok "Selected container engine: $($script:Engine)"
+
     Step 'Install Git for Windows'                          { Install-Git }
-    Step 'Install / enable WSL2 (required by Docker Desktop)' { Install-Wsl }
-    Step 'Install Docker Desktop'                           { Install-DockerDesktop }
+    Step 'Install / enable WSL2 (required by Docker Desktop and Podman)' { Install-Wsl }
+    if ($script:Engine -eq 'podman') {
+        Step 'Install Podman'                               { Install-Podman }
+    } else {
+        Step 'Install Docker Desktop'                       { Install-DockerDesktop }
+    }
     Step 'Clone iic-osic-tools repository'                  { Clone-Repo }
 
     Show-UsageHints
@@ -346,7 +374,7 @@ function Main {
 
     Write-Host ''
     Write-Ok 'All selected installation steps completed.'
-    Write-Host '       If you did not reboot, please do so before launching Docker Desktop.'
+    Write-Host '       If you did not reboot, please do so before launching the container engine.'
 }
 
 try {

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,9 @@
 #
 # The script installs:
 #   * git
-#   * Docker (Docker Engine on Linux / Docker Desktop on macOS)
+#   * A container engine, user-selectable:
+#       - Docker (Docker Engine on Linux / Docker Desktop on macOS), or
+#       - Podman (distribution packages on Linux / Homebrew on macOS)
 #   * XQuartz (macOS only, required for X11 mode)
 #   * Clones the iic-osic-tools repository to a user-chosen directory
 #
@@ -147,6 +149,31 @@ pick_dnf() {
     fi
 }
 
+# ----------------------- container engine choice ---------------------------
+choose_engine() {
+    echo
+    log "IIC-OSIC-TOOLS can be run with Docker (default) or Podman."
+    log "The start scripts auto-detect the installed engine; pick Podman for"
+    log "daemonless, rootless containers (recommended on shared machines)."
+    if ask "Use Podman instead of Docker as the container engine?"; then
+        ENGINE="podman"
+    else
+        ENGINE="docker"
+    fi
+    ok "Selected container engine: $ENGINE"
+}
+
+# Rootless Podman needs subordinate UID/GID ranges for the current user.
+linux_ensure_subids() {
+    if grep -q "^${USER}:" /etc/subuid 2>/dev/null && grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
+        ok "subuid/subgid ranges already configured for '$USER'."
+        return
+    fi
+    log "Rootless Podman needs subuid/subgid ranges for '$USER'."
+    sudo_run usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$USER"
+    ok "Added subuid/subgid ranges for '$USER'."
+}
+
 # ----------------------- Linux (APT) steps --------------------------------
 linux_apt_update() {
     sudo_run apt-get update
@@ -202,6 +229,19 @@ linux_install_docker() {
         sudo_run systemctl enable --now docker.service containerd.service || true
         ok "Docker service enabled & started."
     fi
+}
+
+linux_install_podman() {
+    if have podman; then
+        ok "Podman already installed ($(podman --version))."
+    else
+        sudo_run apt-get install -y podman uidmap slirp4netns
+        # 'passt' provides the modern rootless network backend (pasta); it is
+        # not packaged on older releases, so do not fail if unavailable.
+        sudo_run apt-get install -y passt || warn "Package 'passt' not available; Podman will fall back to slirp4netns."
+        ok "Podman installed."
+    fi
+    linux_ensure_subids
 }
 
 # ----------------------- Linux (DNF/YUM) steps ----------------------------
@@ -270,6 +310,17 @@ linux_dnf_install_docker() {
     fi
 }
 
+linux_dnf_install_podman() {
+    if have podman; then
+        ok "Podman already installed ($(podman --version))."
+    else
+        local pm; pm="$(pick_dnf)"
+        sudo_run "$pm" install -y podman
+        ok "Podman installed."
+    fi
+    linux_ensure_subids
+}
+
 # ----------------------- macOS (Homebrew) steps ---------------------------
 macos_install_brew() {
     if have brew; then
@@ -317,6 +368,30 @@ macos_install_docker() {
     fi
     brew install --cask docker
     ok "Docker Desktop installed. Please launch it once from /Applications to finish setup."
+}
+
+macos_install_podman() {
+    if have podman; then
+        ok "Podman already installed ($(podman --version))."
+    else
+        brew install podman
+        ok "Podman installed via Homebrew."
+    fi
+
+    # On macOS, Podman runs containers inside a Linux VM (the Podman machine).
+    if podman machine inspect >/dev/null 2>&1; then
+        ok "Podman machine already initialized."
+    else
+        log "Initializing the Podman machine (the extracted image needs ~20 GB, so a 60 GB disk is used)."
+        podman machine init --disk-size 60
+        ok "Podman machine initialized."
+    fi
+    if podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q "running"; then
+        ok "Podman machine is running."
+    else
+        podman machine start
+        ok "Podman machine started."
+    fi
 }
 
 macos_install_xquartz() {
@@ -448,6 +523,9 @@ show_usage_hints() {
     echo " 3) Your design files live under \$DESIGNS (default: \$HOME/eda/designs)"
     echo "    and are mounted into the container at /foss/designs."
     echo
+    echo " The start scripts auto-detect Docker or Podman; if both are"
+    echo " installed, override with e.g. CONTAINER_ENGINE=podman ./start_vnc.sh"
+    echo
     echo " The first launch will pull the ~4 GB image from Docker Hub."
     echo " Reserve at least 20 GB of free disk space."
     echo "============================================================"
@@ -457,7 +535,7 @@ show_usage_hints() {
 # ----------------------- macOS reboot -------------------------------------
 macos_reboot() {
     echo
-    warn "macOS: a reboot is recommended to finalize Docker Desktop and XQuartz installation."
+    warn "macOS: a reboot is recommended to finalize the container engine and XQuartz installation."
     if ask "Reboot now? (The system will restart in ~1 minute; press Ctrl-C in that window to abort.)"; then
         # Schedule reboot 1 minute out so the user can recover from an accidental 'y'.
         sudo_run shutdown -r +1 "Rebooting to finalize IIC-OSIC-TOOLS prerequisites." \
@@ -513,31 +591,49 @@ main() {
         die "Aborted by user."
     fi
 
+    choose_engine
+
     case "$OS" in
         linux-apt)
             step "Update APT package lists"               linux_apt_update
             step "Install git and base utilities"         linux_install_git
-            step "Install Docker Engine (official repo)"  linux_install_docker
+            if [[ "$ENGINE" == "podman" ]]; then
+                step "Install Podman (distribution packages)" linux_install_podman
+            else
+                step "Install Docker Engine (official repo)"  linux_install_docker
+            fi
             step "Clone iic-osic-tools repository"        clone_repo
             echo
             ok "All selected Linux steps completed."
-            warn "If you were just added to the 'docker' group, log out and back in (or reboot) before using Docker."
+            if [[ "$ENGINE" == "docker" ]]; then
+                warn "If you were just added to the 'docker' group, log out and back in (or reboot) before using Docker."
+            fi
             show_usage_hints
             ;;
         linux-dnf)
             step "Refresh DNF/YUM metadata"               linux_dnf_update
             step "Install git and base utilities"         linux_dnf_install_git
-            step "Install Docker Engine (official repo)"  linux_dnf_install_docker
+            if [[ "$ENGINE" == "podman" ]]; then
+                step "Install Podman (distribution packages)" linux_dnf_install_podman
+            else
+                step "Install Docker Engine (official repo)"  linux_dnf_install_docker
+            fi
             step "Clone iic-osic-tools repository"        clone_repo
             echo
             ok "All selected Linux steps completed."
-            warn "If you were just added to the 'docker' group, log out and back in (or reboot) before using Docker."
+            if [[ "$ENGINE" == "docker" ]]; then
+                warn "If you were just added to the 'docker' group, log out and back in (or reboot) before using Docker."
+            fi
             show_usage_hints
             ;;
         macos)
             step "Install Homebrew"                       macos_install_brew
             step "Install git via Homebrew"               macos_install_git
-            step "Install Docker Desktop via Homebrew"    macos_install_docker
+            if [[ "$ENGINE" == "podman" ]]; then
+                step "Install Podman via Homebrew"        macos_install_podman
+            else
+                step "Install Docker Desktop via Homebrew" macos_install_docker
+            fi
             step "Install XQuartz via Homebrew"           macos_install_xquartz
             step "Clone iic-osic-tools repository"        clone_repo
             show_usage_hints

--- a/start_jupyter.bat
+++ b/start_jupyter.bat
@@ -36,9 +36,32 @@ if not exist "%DESIGNS%" %ECHO_IF_DRY_RUN% mkdir "%DESIGNS%"
 
 IF NOT DEFINED JUPYTER_PORT SET JUPYTER_PORT=8888
 
+:: Select the container engine (Docker or Podman), can be overridden by
+:: setting CONTAINER_ENGINE.
+IF NOT DEFINED CONTAINER_ENGINE (
+  where /q docker
+  IF NOT ERRORLEVEL 1 (
+    SET CONTAINER_ENGINE=docker
+  ) ELSE (
+    where /q podman
+    IF NOT ERRORLEVEL 1 (
+      SET CONTAINER_ENGINE=podman
+    ) ELSE (
+      ECHO ERROR: No container engine found, please install Docker or Podman!
+      EXIT /B 1
+    )
+  )
+)
+ECHO Using container engine %CONTAINER_ENGINE%
+
 IF NOT DEFINED DOCKER_USER SET DOCKER_USER=hpretl
 IF NOT DEFINED DOCKER_IMAGE SET DOCKER_IMAGE=iic-osic-tools
 IF NOT DEFINED DOCKER_TAG SET DOCKER_TAG=latest
+
+:: Fully qualify the image name (Podman does not resolve short names
+:: non-interactively).
+IF NOT DEFINED DOCKER_REGISTRY SET DOCKER_REGISTRY=docker.io
+SET IMAGE_NAME=%DOCKER_REGISTRY%/%DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
 
 IF NOT DEFINED CONTAINER_USER SET CONTAINER_USER=1000
 IF NOT DEFINED CONTAINER_GROUP SET CONTAINER_GROUP=1000
@@ -53,16 +76,16 @@ IF DEFINED JUPYTER_PORT SET PARAMS=%PARAMS% -p %JUPYTER_PORT%:8888
 IF DEFINED DOCKER_EXTRA_PARAMS SET PARAMS=%PARAMS% %DOCKER_EXTRA_PARAMS%
 
 @REM Check if the container exists and if it is running.
-docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
+%CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
 IF NOT ERRORLEVEL 1 (
-    ECHO Container is running! Stop with \"docker stop %CONTAINER_NAME%\" and remove with \"docker rm %CONTAINER_NAME%\" if required.
+    ECHO Container is running! Stop with \"%CONTAINER_ENGINE% stop %CONTAINER_NAME%\" and remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
 ) ELSE (
-    docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
+    %CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
     IF NOT ERRORLEVEL 1 (
-        echo Container %CONTAINER_NAME% exists. Restart with \"docker start %CONTAINER_NAME%\" or remove with \"docker rm %CONTAINER_NAME%\" if required.
+        echo Container %CONTAINER_NAME% exists. Restart with \"%CONTAINER_ENGINE% start %CONTAINER_NAME%\" or remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
     ) ELSE (
-        echo Container does not exist, pulling %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG% and creating %CONTAINER_NAME% ...
-	%ECHO_IF_DRY_RUN% docker pull %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
-        %ECHO_IF_DRY_RUN% docker run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG% -s jupyter lab --no-browser
+        echo Container does not exist, pulling %IMAGE_NAME% and creating %CONTAINER_NAME% ...
+	%ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% pull %IMAGE_NAME%
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %IMAGE_NAME% -s jupyter lab --no-browser
     )
 )

--- a/start_jupyter.sh
+++ b/start_jupyter.sh
@@ -26,6 +26,29 @@ if [ -n "${DRY_RUN}" ]; then
 	ECHO_IF_DRY_RUN="echo $"
 fi
 
+# Select the container engine (Docker or Podman), can be overridden by
+# setting CONTAINER_ENGINE.
+if [ -z ${CONTAINER_ENGINE+z} ]; then
+	if command -v docker > /dev/null 2>&1; then
+		CONTAINER_ENGINE="docker"
+	elif command -v podman > /dev/null 2>&1; then
+		CONTAINER_ENGINE="podman"
+	else
+		echo "[ERROR] No container engine found, please install Docker or Podman!"
+		exit 1
+	fi
+	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
+fi
+
+# Detect Podman rootless mode on Linux (the docker CLI can also be the
+# podman-docker alias, so check the version string).
+if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
+	if ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+		ENGINE_IS_ROOTLESS=1
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
+	fi
+fi
+
 # SET YOUR DESIGN PATH RIGHT!
 if [ -z ${DESIGNS+z} ]; then
 	DESIGNS=$HOME/eda/designs
@@ -49,6 +72,17 @@ fi
 
 if [ -z ${DOCKER_TAG+z} ]; then
 	DOCKER_TAG="latest"
+fi
+
+# Fully qualify the image name (Podman does not resolve short names
+# non-interactively); set DOCKER_REGISTRY="" to use unqualified names.
+if [ -z ${DOCKER_REGISTRY+z} ]; then
+	DOCKER_REGISTRY="docker.io"
+fi
+if [ -n "${DOCKER_REGISTRY}" ]; then
+	IMAGE_NAME="${DOCKER_REGISTRY}/${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+else
+	IMAGE_NAME="${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
 fi
 
 if [ -z ${CONTAINER_NAME+z} ]; then
@@ -92,6 +126,15 @@ if [[ ${CONTAINER_GROUP} -ne 0 ]]  && [[ ${CONTAINER_GROUP} -lt 1000 ]]; then
         echo
 fi
 
+# In Podman rootless mode, keep the host UID/GID inside the container so
+# bind-mounted files keep their ownership (see README section 5.1).
+if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "${CONTAINER_USER}" != "0" ]; then
+	if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Adding --userns=keep-id for Podman rootless mode."
+		DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} --userns=keep-id"
+	fi
+fi
+
 # Processing ports and other parameters
 # Fixed potential errors in the container due to reduced access to syscalls.
 PARAMS="--security-opt seccomp=unconfined"
@@ -108,43 +151,43 @@ if [ -n "${DOCKER_EXTRA_PARAMS}" ]; then
 fi
 
 # Check if the container exists and if it is running.
-if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container is running!"
-	echo "[HINT] It can also be stopped with \"docker stop ${CONTAINER_NAME}\" and removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be stopped with \"${CONTAINER_ENGINE} stop ${CONTAINER_NAME}\" and removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to stop, and \"r\" to stop & remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 # If the container exists but is exited, it is restarted.
-elif [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
+elif [ "$(${CONTAINER_ENGINE} ps -aq -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container ${CONTAINER_NAME} exists."
-	echo "[HINT] It can also be restarted with \"docker start ${CONTAINER_NAME}\" or removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be restarted with \"${CONTAINER_ENGINE} start ${CONTAINER_NAME}\" or removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to start, and \"r\" to remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker start "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" start "${CONTAINER_NAME}"
 		NB_STARTED=1
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 else
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container does not exist, creating ${CONTAINER_NAME} ..."
 	# Finally, run the container, and sets DISPLAY to the local display number
-	if ! ${ECHO_IF_DRY_RUN} docker pull "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}" > /dev/null; then
-		echo "[ERROR] Failed to pull image ${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}."
+	if ! ${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" pull "${IMAGE_NAME}" > /dev/null; then
+		echo "[ERROR] Failed to pull image ${IMAGE_NAME}."
 		exit 1
 	fi
 	# Disable SC2086, $PARAMS must be globbed and splitted.
 	# shellcheck disable=SC2086
-	if ! ${ECHO_IF_DRY_RUN} docker run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}" -s jupyter lab > /dev/null; then
+	if ! ${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${IMAGE_NAME}" -s jupyter lab > /dev/null; then
 		echo "[ERROR] Failed to start container ${CONTAINER_NAME}."
 		exit 1
 	fi

--- a/start_shell.bat
+++ b/start_shell.bat
@@ -33,9 +33,37 @@ IF "%DESIGNS%"=="" (
 echo Using/creating designs directory: %DESIGNS%
 if not exist "%DESIGNS%" %ECHO_IF_DRY_RUN% mkdir "%DESIGNS%"
 
+:: Select the container engine (Docker or Podman), can be overridden by
+:: setting CONTAINER_ENGINE.
+IF NOT DEFINED CONTAINER_ENGINE (
+  where /q docker
+  IF NOT ERRORLEVEL 1 (
+    SET CONTAINER_ENGINE=docker
+  ) ELSE (
+    where /q podman
+    IF NOT ERRORLEVEL 1 (
+      SET CONTAINER_ENGINE=podman
+    ) ELSE (
+      ECHO ERROR: No container engine found, please install Docker or Podman!
+      EXIT /B 1
+    )
+  )
+)
+ECHO Using container engine %CONTAINER_ENGINE%
+
 IF "%DOCKER_USER%"=="" SET DOCKER_USER=hpretl
 IF "%DOCKER_IMAGE%"=="" SET DOCKER_IMAGE=iic-osic-tools
 IF "%DOCKER_TAG%"=="" SET DOCKER_TAG=latest
+
+:: Fully qualify the image name (Podman does not resolve short names
+:: non-interactively).
+IF "%DOCKER_REGISTRY%"=="" SET DOCKER_REGISTRY=docker.io
+SET IMAGE_NAME=%DOCKER_REGISTRY%/%DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
+
+:: Docker Desktop and Podman machine expose the host WSLg directory at
+:: different locations inside their WSL2 VMs.
+SET WSLG_ROOT=/run/desktop/mnt/host/wslg
+IF "%CONTAINER_ENGINE%"=="podman" SET WSLG_ROOT=/mnt/wslg
 
 IF "%CONTAINER_USER%"=="" SET CONTAINER_USER=0
 IF "%CONTAINER_GROUP%"=="" SET CONTAINER_GROUP=0
@@ -50,16 +78,16 @@ IF %CONTAINER_GROUP% NEQ 0 if %CONTAINER_GROUP% LSS 1000 echo WARNING: Selected 
 
 SET PARAMS=--security-opt seccomp=unconfined
 
-docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
+%CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
 IF NOT ERRORLEVEL 1 (
-    ECHO Container is running! Stop with \"docker stop %CONTAINER_NAME%\" and remove with \"docker rm %CONTAINER_NAME%\" if required.
+    ECHO Container is running! Stop with \"%CONTAINER_ENGINE% stop %CONTAINER_NAME%\" and remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
 ) ELSE (
-    docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
+    %CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
     IF NOT ERRORLEVEL 1 (
-        echo Container %CONTAINER_NAME% exists. Restart with \"docker start %CONTAINER_NAME%\" or remove with \"docker rm %CONTAINER_NAME%\" if required.
+        echo Container %CONTAINER_NAME% exists. Restart with \"%CONTAINER_ENGINE% start %CONTAINER_NAME%\" or remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
     ) ELSE (
-	echo Container does not exist, pulling %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG% and creating %CONTAINER_NAME% ...
-        %ECHO_IF_DRY_RUN% docker pull %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
-        %ECHO_IF_DRY_RUN% docker run -it --user %CONTAINER_USER%:%CONTAINER_GROUP% -e DISPLAY=%DISP% -e WAYLAND_DISPLAY=%WAYLAND_DISP% -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir -e PULSE_SERVER=/mnt/wslg/PulseServer -v /run/desktop/mnt/host/wslg/.X11-unix:/tmp/.X11-unix -v /run/desktop/mnt/host/wslg:/mnt/wslg --device=/dev/dxg -v /usr/lib/wsl:/usr/lib/wsl %DOCKER_EXTRA_PARAMS% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG% -s /bin/bash
+	echo Container does not exist, pulling %IMAGE_NAME% and creating %CONTAINER_NAME% ...
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% pull %IMAGE_NAME%
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% run -it --user %CONTAINER_USER%:%CONTAINER_GROUP% -e DISPLAY=%DISP% -e WAYLAND_DISPLAY=%WAYLAND_DISP% -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir -e PULSE_SERVER=/mnt/wslg/PulseServer -v %WSLG_ROOT%/.X11-unix:/tmp/.X11-unix -v %WSLG_ROOT%:/mnt/wslg --device=/dev/dxg -v /usr/lib/wsl:/usr/lib/wsl %DOCKER_EXTRA_PARAMS% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %IMAGE_NAME% -s /bin/bash
     )
 )

--- a/start_shell.sh
+++ b/start_shell.sh
@@ -24,6 +24,29 @@ if [ -n "${DRY_RUN}" ]; then
 	ECHO_IF_DRY_RUN="echo $"
 fi
 
+# Select the container engine (Docker or Podman), can be overridden by
+# setting CONTAINER_ENGINE.
+if [ -z ${CONTAINER_ENGINE+z} ]; then
+	if command -v docker > /dev/null 2>&1; then
+		CONTAINER_ENGINE="docker"
+	elif command -v podman > /dev/null 2>&1; then
+		CONTAINER_ENGINE="podman"
+	else
+		echo "[ERROR] No container engine found, please install Docker or Podman!"
+		exit 1
+	fi
+	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
+fi
+
+# Detect Podman rootless mode on Linux (the docker CLI can also be the
+# podman-docker alias, so check the version string).
+if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
+	if ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+		ENGINE_IS_ROOTLESS=1
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
+	fi
+fi
+
 # SET YOUR DESIGN PATH RIGHT!
 if [ -z ${DESIGNS+z} ]; then
 	DESIGNS=$HOME/eda/designs
@@ -43,6 +66,17 @@ fi
 
 if [ -z ${DOCKER_TAG+z} ]; then
 	DOCKER_TAG="latest"
+fi
+
+# Fully qualify the image name (Podman does not resolve short names
+# non-interactively); set DOCKER_REGISTRY="" to use unqualified names.
+if [ -z ${DOCKER_REGISTRY+z} ]; then
+	DOCKER_REGISTRY="docker.io"
+fi
+if [ -n "${DOCKER_REGISTRY}" ]; then
+	IMAGE_NAME="${DOCKER_REGISTRY}/${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+else
+	IMAGE_NAME="${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
 fi
 
 # Shell starts as root per default.
@@ -84,42 +118,53 @@ fi
 # Fixed potential errors in the container due to reduced access to syscalls.
 DOCKER_EXTRA_PARAMS="--security-opt seccomp=unconfined ${DOCKER_EXTRA_PARAMS}"
 
+# In Podman rootless mode, keep the host UID/GID inside the container so
+# bind-mounted files keep their ownership (see README section 5.1). Not
+# needed for the default root shell, where container root maps to the host
+# user anyway.
+if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "${CONTAINER_USER}" != "0" ]; then
+	if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Adding --userns=keep-id for Podman rootless mode."
+		DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} --userns=keep-id"
+	fi
+fi
+
 if [ -n "${IIC_OSIC_TOOLS_QUIET}" ]; then
 	DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} -e IIC_OSIC_TOOLS_QUIET=1"
 fi
 
 # Check if the container exists and if it is running.
-if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container is running!"
-	echo "[HINT] It can also be stopped with \"docker stop ${CONTAINER_NAME}\" and removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be stopped with \"${CONTAINER_ENGINE} stop ${CONTAINER_NAME}\" and removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to stop, and \"r\" to stop & remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 # If the container exists but is exited, it is restarted.
-elif [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
+elif [ "$(${CONTAINER_ENGINE} ps -aq -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container ${CONTAINER_NAME} exists."
-	echo "[HINT] It can also be restarted with \"docker start ${CONTAINER_NAME}\" or removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be restarted with \"${CONTAINER_ENGINE} start ${CONTAINER_NAME}\" or removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to start, and \"r\" to remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker start -a -i "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" start -a -i "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 else
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container does not exist, creating ${CONTAINER_NAME} ..."
 	# Finally, run the container, and set DISPLAY to the local display number
-	#${ECHO_IF_DRY_RUN} docker pull "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+	#${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" pull "${IMAGE_NAME}"
 	# Disable SC2086, $PARAMS must be globbed and splitted.
 	# shellcheck disable=SC2086
-	${ECHO_IF_DRY_RUN} docker run -it --name "${CONTAINER_NAME}" --user "${CONTAINER_USER}:${CONTAINER_GROUP}" -e "DISPLAY=${DISP}" $DOCKER_EXTRA_PARAMS -v "${DESIGNS}":"/foss/designs":rw "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}" -s /bin/bash
+	${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -it --name "${CONTAINER_NAME}" --user "${CONTAINER_USER}:${CONTAINER_GROUP}" -e "DISPLAY=${DISP}" $DOCKER_EXTRA_PARAMS -v "${DESIGNS}":"/foss/designs":rw "${IMAGE_NAME}" -s /bin/bash
 fi

--- a/start_vnc.bat
+++ b/start_vnc.bat
@@ -89,6 +89,11 @@ IF DEFINED IIC_SERVER_DEPLOYMENT (
   SET PARAMS=--security-opt seccomp=unconfined
 )
 
+:: Docker sets this namespaced sysctl to 0 in every container by default,
+:: Podman does not; it is required so noVNC (running as a non-root user) can
+:: bind port 80 inside the container.
+IF "%CONTAINER_ENGINE%"=="podman" SET PARAMS=%PARAMS% --sysctl net.ipv4.ip_unprivileged_port_start=0
+
 IF %WEBSERVER_PORT% GTR 0 (
   SET PARAMS=%PARAMS% -p %WEBSERVER_PORT%:80
 )

--- a/start_vnc.bat
+++ b/start_vnc.bat
@@ -33,9 +33,32 @@ IF "%DESIGNS%"=="" (
 echo Using/creating designs directory: %DESIGNS%
 if not exist "%DESIGNS%" %ECHO_IF_DRY_RUN% mkdir "%DESIGNS%" 
 
+:: Select the container engine (Docker or Podman), can be overridden by
+:: setting CONTAINER_ENGINE.
+IF NOT DEFINED CONTAINER_ENGINE (
+  where /q docker
+  IF NOT ERRORLEVEL 1 (
+    SET CONTAINER_ENGINE=docker
+  ) ELSE (
+    where /q podman
+    IF NOT ERRORLEVEL 1 (
+      SET CONTAINER_ENGINE=podman
+    ) ELSE (
+      ECHO ERROR: No container engine found, please install Docker or Podman!
+      EXIT /B 1
+    )
+  )
+)
+ECHO Using container engine %CONTAINER_ENGINE%
+
 IF "%DOCKER_USER%"=="" SET DOCKER_USER=hpretl
 IF "%DOCKER_IMAGE%"=="" SET DOCKER_IMAGE=iic-osic-tools
 IF "%DOCKER_TAG%"=="" SET DOCKER_TAG=latest
+
+:: Fully qualify the image name (Podman does not resolve short names
+:: non-interactively).
+IF "%DOCKER_REGISTRY%"=="" SET DOCKER_REGISTRY=docker.io
+SET IMAGE_NAME=%DOCKER_REGISTRY%/%DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
 
 IF "%CONTAINER_USER%"=="" SET CONTAINER_USER=1000
 IF "%CONTAINER_GROUP%"=="" SET CONTAINER_GROUP=1000
@@ -90,16 +113,16 @@ IF DEFINED DOCKER_EXTRA_PARAMS (
   SET PARAMS=%PARAMS% %DOCKER_EXTRA_PARAMS%
 )
 
-docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
+%CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
 IF NOT ERRORLEVEL 1 (
-    ECHO Container is running! Stop with \"docker stop %CONTAINER_NAME%\" and remove with \"docker rm %CONTAINER_NAME%\" if required.
+    ECHO Container is running! Stop with \"%CONTAINER_ENGINE% stop %CONTAINER_NAME%\" and remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
 ) ELSE (
-    docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
+    %CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
     IF NOT ERRORLEVEL 1 (
-        echo Container %CONTAINER_NAME% exists. Restart with \"docker start %CONTAINER_NAME%\" or remove with \"docker rm %CONTAINER_NAME%\" if required.
+        echo Container %CONTAINER_NAME% exists. Restart with \"%CONTAINER_ENGINE% start %CONTAINER_NAME%\" or remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
     ) ELSE (
         echo Container does not exist, creating %CONTAINER_NAME% ...
-        %ECHO_IF_DRY_RUN% docker run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %IMAGE_NAME%
         IF %WEBSERVER_PORT% GTR 0 (
             IF DEFINED VNC_PW (
                 echo [INFO] To access the VNC session, open a browser and navigate to http://localhost:%WEBSERVER_PORT%/?password=%VNC_PW%

--- a/start_vnc.sh
+++ b/start_vnc.sh
@@ -38,10 +38,11 @@ if [ -z ${CONTAINER_ENGINE+z} ]; then
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
 fi
 
-# Detect Podman rootless mode on Linux (the docker CLI can also be the
-# podman-docker alias, so check the version string).
-if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
-	if ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+# Detect Podman, and Podman rootless mode on Linux (the docker CLI can also
+# be the podman-docker alias, so check the version string).
+if ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
+	ENGINE_IS_PODMAN=1
+	if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
 		ENGINE_IS_ROOTLESS=1
 		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
 	fi
@@ -151,6 +152,12 @@ if [ -n "${IIC_SERVER_DEPLOYMENT}" ]; then
 	PARAMS=""
 else
 	PARAMS="--security-opt seccomp=unconfined"
+fi
+# Docker sets this namespaced sysctl to 0 in every container by default,
+# Podman does not; it is required so noVNC (running as a non-root user) can
+# bind port 80 inside the container.
+if [ -n "${ENGINE_IS_PODMAN}" ]; then
+	PARAMS="${PARAMS} --sysctl net.ipv4.ip_unprivileged_port_start=0"
 fi
 if [ "$WEBSERVER_PORT" -gt 0 ]; then
 	PARAMS="$PARAMS -p $WEBSERVER_PORT:80"

--- a/start_vnc.sh
+++ b/start_vnc.sh
@@ -24,6 +24,29 @@ if [ -n "${DRY_RUN}" ]; then
 	ECHO_IF_DRY_RUN="echo $"
 fi
 
+# Select the container engine (Docker or Podman), can be overridden by
+# setting CONTAINER_ENGINE.
+if [ -z ${CONTAINER_ENGINE+z} ]; then
+	if command -v docker > /dev/null 2>&1; then
+		CONTAINER_ENGINE="docker"
+	elif command -v podman > /dev/null 2>&1; then
+		CONTAINER_ENGINE="podman"
+	else
+		echo "[ERROR] No container engine found, please install Docker or Podman!"
+		exit 1
+	fi
+	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
+fi
+
+# Detect Podman rootless mode on Linux (the docker CLI can also be the
+# podman-docker alias, so check the version string).
+if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
+	if ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+		ENGINE_IS_ROOTLESS=1
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
+	fi
+fi
+
 # SET YOUR DESIGN PATH RIGHT!
 if [ -z ${DESIGNS+z} ]; then
 	DESIGNS=$HOME/eda/designs
@@ -35,7 +58,15 @@ fi
 
 # Set the host ports, and disable them with 0. Only used if not set as shell variables!
 if [ -z ${WEBSERVER_PORT+z} ]; then
-	WEBSERVER_PORT=80
+	if [ -n "${ENGINE_IS_ROOTLESS}" ]; then
+		# Rootless Podman cannot bind ports below 1024 by default.
+		WEBSERVER_PORT=8080
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Webserver port auto-set to ${WEBSERVER_PORT} (rootless Podman cannot bind ports below 1024)."
+	else
+		WEBSERVER_PORT=80
+	fi
+elif [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "$WEBSERVER_PORT" -gt 0 ] && [ "$WEBSERVER_PORT" -lt 1024 ]; then
+	echo "[WARNING] Rootless Podman cannot bind port ${WEBSERVER_PORT} (below 1024) by default, the container will likely fail to start. Use e.g. WEBSERVER_PORT=8080."
 fi
 if [ -z ${VNC_PORT+z} ]; then
 	VNC_PORT=5901
@@ -51,6 +82,17 @@ fi
 
 if [ -z ${DOCKER_TAG+z} ]; then
 	DOCKER_TAG="latest"
+fi
+
+# Fully qualify the image name (Podman does not resolve short names
+# non-interactively); set DOCKER_REGISTRY="" to use unqualified names.
+if [ -z ${DOCKER_REGISTRY+z} ]; then
+	DOCKER_REGISTRY="docker.io"
+fi
+if [ -n "${DOCKER_REGISTRY}" ]; then
+	IMAGE_NAME="${DOCKER_REGISTRY}/${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+else
+	IMAGE_NAME="${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
 fi
 
 if [ -z ${CONTAINER_NAME+z} ]; then
@@ -94,6 +136,15 @@ if [[ ${CONTAINER_GROUP} -ne 0 ]]  && [[ ${CONTAINER_GROUP} -lt 1000 ]]; then
         echo
 fi
 
+# In Podman rootless mode, keep the host UID/GID inside the container so
+# bind-mounted files keep their ownership (see README section 5.1).
+if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "${CONTAINER_USER}" != "0" ]; then
+	if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Adding --userns=keep-id for Podman rootless mode."
+		DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} --userns=keep-id"
+	fi
+fi
+
 # Processing ports and other parameters
 # Fixed potential errors in the container due to reduced access to syscalls.
 if [ -n "${IIC_SERVER_DEPLOYMENT}" ]; then
@@ -127,38 +178,38 @@ if [ -n "${DOCKER_EXTRA_PARAMS}" ]; then
 fi
 
 # Check if the container exists and if it is running.
-if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container is running!"
-	echo "[HINT] It can also be stopped with \"docker stop ${CONTAINER_NAME}\" and removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be stopped with \"${CONTAINER_ENGINE} stop ${CONTAINER_NAME}\" and removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to stop, and \"r\" to stop & remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 # If the container exists but is exited, it is restarted.
-elif [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
+elif [ "$(${CONTAINER_ENGINE} ps -aq -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container ${CONTAINER_NAME} exists."
-	echo "[HINT] It can also be restarted with \"docker start ${CONTAINER_NAME}\" or removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be restarted with \"${CONTAINER_ENGINE} start ${CONTAINER_NAME}\" or removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to start, and \"r\" to remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker start "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" start "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 else
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container does not exist, creating ${CONTAINER_NAME} ..."
 	# Finally, run the container, and sets DISPLAY to the local display number
-	#${ECHO_IF_DRY_RUN} docker pull "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+	#${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" pull "${IMAGE_NAME}"
 	# Disable SC2086, $PARAMS must be globbed and splitted.
 	# shellcheck disable=SC2086
-	${ECHO_IF_DRY_RUN} docker run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}" > /dev/null
+	${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${IMAGE_NAME}" > /dev/null
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && [ "$WEBSERVER_PORT" -gt 0 ] && echo "[INFO] To access the VNC session, open a browser and navigate to http://localhost:${WEBSERVER_PORT}/?password=${VNC_PW:-abc123}"
 fi

--- a/start_x.bat
+++ b/start_x.bat
@@ -33,9 +33,37 @@ IF "%DESIGNS%"=="" (
 echo Using/creating designs directory: %DESIGNS%
 if not exist "%DESIGNS%" %ECHO_IF_DRY_RUN% mkdir "%DESIGNS%" 
 
+:: Select the container engine (Docker or Podman), can be overridden by
+:: setting CONTAINER_ENGINE.
+IF NOT DEFINED CONTAINER_ENGINE (
+  where /q docker
+  IF NOT ERRORLEVEL 1 (
+    SET CONTAINER_ENGINE=docker
+  ) ELSE (
+    where /q podman
+    IF NOT ERRORLEVEL 1 (
+      SET CONTAINER_ENGINE=podman
+    ) ELSE (
+      ECHO ERROR: No container engine found, please install Docker or Podman!
+      EXIT /B 1
+    )
+  )
+)
+ECHO Using container engine %CONTAINER_ENGINE%
+
 IF "%DOCKER_USER%"=="" SET DOCKER_USER=hpretl
 IF "%DOCKER_IMAGE%"=="" SET DOCKER_IMAGE=iic-osic-tools
 IF "%DOCKER_TAG%"=="" SET DOCKER_TAG=latest
+
+:: Fully qualify the image name (Podman does not resolve short names
+:: non-interactively).
+IF "%DOCKER_REGISTRY%"=="" SET DOCKER_REGISTRY=docker.io
+SET IMAGE_NAME=%DOCKER_REGISTRY%/%DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
+
+:: Docker Desktop and Podman machine expose the host WSLg directory at
+:: different locations inside their WSL2 VMs.
+SET WSLG_ROOT=/run/desktop/mnt/host/wslg
+IF "%CONTAINER_ENGINE%"=="podman" SET WSLG_ROOT=/mnt/wslg
 
 IF "%CONTAINER_USER%"=="" SET CONTAINER_USER=1000
 IF "%CONTAINER_GROUP%"=="" SET CONTAINER_GROUP=1000
@@ -55,16 +83,16 @@ IF DEFINED DOCKER_EXTRA_PARAMS (
 )
 
 
-docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
+%CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "running"
 IF NOT ERRORLEVEL 1 (
-    ECHO Container is running! Stop with \"docker stop %CONTAINER_NAME%\" and remove with \"docker rm %CONTAINER_NAME%\" if required.
+    ECHO Container is running! Stop with \"%CONTAINER_ENGINE% stop %CONTAINER_NAME%\" and remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
 ) ELSE (
-    docker container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
+    %CONTAINER_ENGINE% container inspect %CONTAINER_NAME% 2>&1 | find "Status" | find /i "exited"
     IF NOT ERRORLEVEL 1 (
-        echo Container %CONTAINER_NAME% exists. Restart with \"docker start %CONTAINER_NAME%\" or remove with \"docker rm %CONTAINER_NAME%\" if required.
+        echo Container %CONTAINER_NAME% exists. Restart with \"%CONTAINER_ENGINE% start %CONTAINER_NAME%\" or remove with \"%CONTAINER_ENGINE% rm %CONTAINER_NAME%\" if required.
     ) ELSE (
-	echo Container does not exist, pulling %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG% and creating %CONTAINER_NAME% ...
-        %ECHO_IF_DRY_RUN% docker pull %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
-        %ECHO_IF_DRY_RUN% docker run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% -e DISPLAY=%DISP% -e WAYLAND_DISPLAY=%WAYLAND_DISP% -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir -e PULSE_SERVER=/mnt/wslg/PulseServer -v /run/desktop/mnt/host/wslg/.X11-unix:/tmp/.X11-unix -v /run/desktop/mnt/host/wslg:/mnt/wslg --device=/dev/dxg -v /usr/lib/wsl:/usr/lib/wsl %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %DOCKER_USER%/%DOCKER_IMAGE%:%DOCKER_TAG%
+	echo Container does not exist, pulling %IMAGE_NAME% and creating %CONTAINER_NAME% ...
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% pull %IMAGE_NAME%
+        %ECHO_IF_DRY_RUN% %CONTAINER_ENGINE% run -d --user %CONTAINER_USER%:%CONTAINER_GROUP% -e DISPLAY=%DISP% -e WAYLAND_DISPLAY=%WAYLAND_DISP% -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir -e PULSE_SERVER=/mnt/wslg/PulseServer -v %WSLG_ROOT%/.X11-unix:/tmp/.X11-unix -v %WSLG_ROOT%:/mnt/wslg --device=/dev/dxg -v /usr/lib/wsl:/usr/lib/wsl %PARAMS% -v "%DESIGNS%":/foss/designs --name %CONTAINER_NAME% %IMAGE_NAME%
     )
 )

--- a/start_x.sh
+++ b/start_x.sh
@@ -52,23 +52,47 @@ if [ -n "${DRY_RUN}" ]; then
 	ECHO_IF_DRY_RUN="echo $"
 fi
 
+# Select the container engine (Docker or Podman), can be overridden by
+# setting CONTAINER_ENGINE.
+if [ -z ${CONTAINER_ENGINE+z} ]; then
+	if command -v docker > /dev/null 2>&1; then
+		CONTAINER_ENGINE="docker"
+	elif command -v podman > /dev/null 2>&1; then
+		CONTAINER_ENGINE="podman"
+	else
+		echo "[ERROR] No container engine found, please install Docker or Podman!"
+		exit 1
+	fi
+	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
+fi
+
+# Detect Podman, and Podman rootless mode on Linux (the docker CLI can also
+# be the podman-docker alias, so check the version string).
+if ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
+	ENGINE_IS_PODMAN=1
+	if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+		ENGINE_IS_ROOTLESS=1
+		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
+	fi
+fi
+
 if [ -z ${CONTAINER_NAME+z} ]; then
 	CONTAINER_NAME="iic-osic-tools_xserver_uid_"$(id -u)
 fi
 
 # Check if the container exists and if it is running.
-if [ "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
+if [ "$(${CONTAINER_ENGINE} ps -q -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container is running!"
-	echo "[HINT] It can also be stopped with \"docker stop ${CONTAINER_NAME}\" and removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be stopped with \"${CONTAINER_ENGINE} stop ${CONTAINER_NAME}\" and removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo
 	echo -n "Press \"s\" to stop, and \"r\" to stop & remove: "
 	read -r -n 1 k </dev/tty
 	echo
 	if [[ $k = s ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker stop "${CONTAINER_NAME}"
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" stop "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 fi
 
@@ -95,6 +119,17 @@ if [ -z ${DOCKER_TAG+z} ]; then
 	DOCKER_TAG="latest"
 fi
 
+# Fully qualify the image name (Podman does not resolve short names
+# non-interactively); set DOCKER_REGISTRY="" to use unqualified names.
+if [ -z ${DOCKER_REGISTRY+z} ]; then
+	DOCKER_REGISTRY="docker.io"
+fi
+if [ -n "${DOCKER_REGISTRY}" ]; then
+	IMAGE_NAME="${DOCKER_REGISTRY}/${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+else
+	IMAGE_NAME="${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+fi
+
 if [[ "$OSTYPE" == "linux"* ]]; then
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Auto detected Linux."
 	# Should also be a sensible default
@@ -113,20 +148,17 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 	fi
 	PARAMS="${PARAMS} -e XDG_RUNTIME_DIR=${CONTAINER_XDG_RUNTIME_DIR}"
 
-	# Detect if Podman is being used as the container runtime (docker CLI may be an alias for Podman)
-	if docker --version 2>/dev/null | grep -qi "podman" || docker info 2>/dev/null | grep -qi "podman"; then
-		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman detected as container runtime."
-		if podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
-			[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
-			if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
-				echo "[INFO] For better X11/Wayland compatibility in Podman rootless mode, consider using:"
-				echo "       DOCKER_EXTRA_PARAMS=\"--userns=keep-id\" ./start_x.sh"
-			fi
+	# In Podman rootless mode, keep the host UID/GID inside the container for
+	# X11/Wayland socket access and bind-mount file ownership (see README 5.1).
+	if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "${CONTAINER_USER}" != "0" ]; then
+		if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
+			[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Adding --userns=keep-id for Podman rootless mode."
+			DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} --userns=keep-id"
 		fi
 	fi
 
 	# Check if Docker is running on Docker Desktop or classic engine
-	docker_info=$(docker version --format '{{.Server.Version}} {{.Server.Os}} {{.Server.Platform.Name}}' 2>/dev/null)
+	docker_info=$(${CONTAINER_ENGINE} version --format '{{.Server.Version}} {{.Server.Os}} {{.Server.Platform.Name}}' 2>/dev/null)
 
 	if echo "$docker_info" | grep -iq "Docker Desktop"; then
 		# We are running on Docker Desktop, means no forwarded special files...
@@ -247,7 +279,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 	        CONTAINER_GROUP=1000
 	fi
 	if [ -z ${DISP+z} ]; then
-		DISP="host.docker.internal:0"
+		if [ -n "${ENGINE_IS_PODMAN}" ]; then
+			# Podman machine resolves the host as host.containers.internal.
+			DISP="host.containers.internal:0"
+		else
+			DISP="host.docker.internal:0"
+		fi
 		if [[ $(type -P "xhost") ]]; then
 			${ECHO_IF_DRY_RUN} xhost +localhost > /dev/null
 			# Note: do NOT reset xhost on script exit. The container is started
@@ -303,9 +340,9 @@ if [ -n "${DOCKER_EXTRA_PARAMS}" ]; then
 fi
 
 # If the container exists but is exited, it can be restarted.
-if [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
+if [ "$(${CONTAINER_ENGINE} ps -aq -f name="${CONTAINER_NAME}")" ]; then
 	echo "[WARNING] Container ${CONTAINER_NAME} exists."
-	echo "[HINT] It can also be restarted with \"docker start ${CONTAINER_NAME}\" or removed with \"docker rm ${CONTAINER_NAME}\" if required."
+	echo "[HINT] It can also be restarted with \"${CONTAINER_ENGINE} start ${CONTAINER_NAME}\" or removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\" if required."
 	echo	
 	echo -n "Press \"s\" to start, and \"r\" to remove: "
 	read -r -n 1 k </dev/tty
@@ -319,7 +356,7 @@ if [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
 		# the file /headless/.xauthority. Recreate the recorded source as a file
 		# (with the freshly generated cookie) before starting. See issue #300.
 		if [ -z "${ECHO_IF_DRY_RUN}" ]; then
-			XAUTH_SRC=$(docker inspect -f '{{range .Mounts}}{{if eq .Destination "/headless/.xauthority"}}{{.Source}}{{end}}{{end}}' "${CONTAINER_NAME}" 2>/dev/null)
+			XAUTH_SRC=$(${CONTAINER_ENGINE} inspect -f '{{range .Mounts}}{{if eq .Destination "/headless/.xauthority"}}{{.Source}}{{end}}{{end}}' "${CONTAINER_NAME}" 2>/dev/null)
 			if [ -n "${XAUTH_SRC}" ] && [ ! -f "${XAUTH_SRC}" ]; then
 				echo "[INFO] Recreating missing xauthority bind-mount source ${XAUTH_SRC} before restart."
 				# Remove a stale directory that a previous failed start may have created.
@@ -332,17 +369,17 @@ if [ "$(docker ps -aq -f name="${CONTAINER_NAME}")" ]; then
 				chmod 600 "${XAUTH_SRC}" 2>/dev/null || true
 			fi
 		fi
-		${ECHO_IF_DRY_RUN} docker start "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" start "${CONTAINER_NAME}"
 	elif [[ $k = r ]] ; then
-		${ECHO_IF_DRY_RUN} docker rm "${CONTAINER_NAME}"
+		${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" rm "${CONTAINER_NAME}"
 	fi
 else
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container does not exist, creating ${CONTAINER_NAME}. Please be patient, this can take a few minutes ..."
 	# Finally, run the container, and set DISPLAY to the local display number
-	${ECHO_IF_DRY_RUN} docker pull "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}" > /dev/null
+	${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" pull "${IMAGE_NAME}" > /dev/null
 	# Disable SC2086, $PARAMS must be globbed and splitted.
 	# shellcheck disable=SC2086
-	${ECHO_IF_DRY_RUN} docker run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" -e "DISPLAY=${DISP}" -v "${DESIGNS}":"/foss/designs":rw ${PARAMS} --name "${CONTAINER_NAME}" "${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}"
+	${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" -e "DISPLAY=${DISP}" -v "${DESIGNS}":"/foss/designs":rw ${PARAMS} --name "${CONTAINER_NAME}" "${IMAGE_NAME}"
 fi
 
 if [ -n "${SOCAT_PID}" ]; then
@@ -352,8 +389,8 @@ if [ -n "${SOCAT_PID}" ]; then
 	# Check if socat is still running and monitor the container status
 	while ps -p "${SOCAT_PID}" > /dev/null; do
 		# Check if the container is still running
-		if ! docker ps --filter "name=${CONTAINER_NAME}" --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-			echo "Docker container ${CONTAINER_NAME} is no longer running."
+		if ! ${CONTAINER_ENGINE} ps --filter "name=${CONTAINER_NAME}" --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+			echo "Container ${CONTAINER_NAME} is no longer running."
 			cleanup
 		fi
 


### PR DESCRIPTION
Introduces container engine auto-detection (`docker` preferred, fallback to `podman`) with `CONTAINER_ENGINE` override in all start scripts and EDA server scripts, and switches runtime commands from hardcoded `docker` to the selected engine. Adds Podman-specific handling for rootless mode (`--userns=keep-id` injection, VNC default port 8080 warning/default behavior), fully qualified image names via `DOCKER_REGISTRY`, and WSLg/macOS host adjustments for Podman networking/paths. Installers (`install.sh`, `install.ps1`) now let users choose Docker or Podman and perform Podman setup steps. README and known-issues docs were updated to reflect the new first-class Podman workflow and rootless behavior.