### PR TITLE
Patch ciel gf180mcu pcells for current gdsfactory at install time

### DIFF
--- a/_build/images/open_pdks/patches/gf180mcu-pcells-gdsfactory9.patch
+++ b/_build/images/open_pdks/patches/gf180mcu-pcells-gdsfactory9.patch
@@ -1,0 +1,443 @@
+diff -ruN a/cells/__init__.py b/cells/__init__.py
+--- a/cells/__init__.py	2026-07-23 00:45:08.561908721 +0200
++++ b/cells/__init__.py	2026-07-23 00:45:08.574694888 +0200
+@@ -135,3 +135,7 @@
+ 
+         # Register us with the name "gf180mcu".
+         self.register("gf180mcu")
++
++
++from ._patches import patch_legacy_classes
++patch_legacy_classes()
+diff -ruN a/cells/_patches.py b/cells/_patches.py
+--- a/cells/_patches.py	2026-07-23 00:45:08.563084217 +0200
++++ b/cells/_patches.py	2026-07-23 00:45:08.575817010 +0200
+@@ -1,12 +1,215 @@
++# Copyright 2025 GlobalFoundries PDK Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
+ 
++# ==============================================================================
++# ---------------- Patches for compatibility with gdsfactory v9 ----------------
++# ==============================================================================
+ 
+-def _activate_generic_pdk():
++def _patch_class_attr(cls, name, attr, force=False):
++    """
++    Add or replace an attribute (method or property) on a class.
++
++    Args:
++        cls: The class to patch.
++        name: The name of the attribute to add.
++        attr: The method or property object.
++        force: If True, will override existing attributes.
++    """
++    if not hasattr(cls, name) or force:
++        setattr(cls, name, attr)
++    else:
++        print(f"[patch_class_attr] Skipped: '{cls.__name__}.{name}' already exists.")
++
++
++def patch_legacy_classes():
+     import gdsfactory as gf
++    from importlib.util import find_spec
++    from typing import Optional
++
++    #
++    # Replacement for gdsfactory.Component.add_array() method
++    #
++
++    # noinspection PyPep8Naming
++    def __gf__Component__add_array(
++        self: gf.Component,
++        component: gf.Component,
++        columns: int = 2,
++        rows: int = 2,
++        spacing: tuple[float, float] = (100, 100),
++        alias: Optional[str] = None
++    ) -> gf.ComponentReference:
++        column_pitch = spacing[0]
++        row_pitch = spacing[1]
++        ref = self.add_ref(
++            component=component,
++            name=alias,
++            columns=columns,
++            rows=rows,
++            column_pitch=column_pitch,
++            row_pitch=row_pitch
++        )
++        return ref
++
++
++    # noinspection PyPep8Naming
++    def __gf__component_layout___GeometryHelper__size(self):  # gf.component_layout._GeometryHelper
++        return self.xsize, self.ysize
++
++
++    _patch_class_attr(gf.Component, 'add_array', __gf__Component__add_array)
++    _patch_class_attr(gf.Component, 'size', property(__gf__component_layout___GeometryHelper__size))
++    _patch_class_attr(gf.ComponentReference, 'size', property(__gf__component_layout___GeometryHelper__size))
++
++    # class gdsfactory.geometry.boolean (v7) now resides under gdsfactory.boolean (v9)
++    if find_spec('gdsfactory.geometry') is None:
++        class DummyNamespace:
++            pass
++        gf__geometry = DummyNamespace()
++        gf__geometry.boolean = gf.boolean
++        gf.geometry = gf__geometry
++
++
++    # gf.Component("nfet_dev") for example would yield the error below, e.g. when changing PCell parameters
++    #
++    #ERROR: ValueError: Cellname nfet_dev already exists. Please make sure the cellname is unique or pass `allow_duplicate` when creating the library in PCellDeclaration.produce
++    #  /usr/local/lib/python3.12/dist-packages/kfactory/layout.py:1209
++    #  /usr/local/lib/python3.12/dist-packages/kfactory/kcell.py:594
++    #  /usr/local/lib/python3.12/dist-packages/kfactory/kcell.py:2563
++
++    import klayout.db as kdb
++    import kfactory.layout
++    original_method = kfactory.layout.KCLayout.create_cell
++
++    # noinspection PyPep8Naming
++    def __kfactory__layout__KCLayout_create_cell(
++        self,
++        name: str,
++        *args: str,
++        allow_duplicate: bool = True,
++    ) -> kdb.Cell:
++        return original_method(self, name, *args, allow_duplicate=allow_duplicate)
+ 
++    kfactory.layout.KCLayout.create_cell = __kfactory__layout__KCLayout_create_cell
++
++    #
++    # Emulate the gdsfactory v7 get_polygons(by_spec=...) API:
++    #   by_spec=True          -> {(layer, datatype): [ndarray of (x_um, y_um), ...]}
++    #   by_spec=(l, d)        -> [ndarray of (x_um, y_um), ...] for that layer only
++    # Modern calls (no by_spec) pass through unchanged. Also provided on
++    # ComponentReference/Instance (v7 allowed it on references; coordinates are
++    # returned in the parent frame, i.e. with the instance transform applied).
++    #
++    import numpy as _np
++
++    _orig_get_polygons = gf.Component.get_polygons
++
++    def __v7_polys_um(polys, dbu):
++        return [
++            _np.array([(pt.x * dbu, pt.y * dbu) for pt in poly.each_point_hull()])
++            for poly in polys
++        ]
++
++    # noinspection PyPep8Naming
++    def __gf__Component__get_polygons_v7compat(self, by_spec=False, **kwargs):
++        if by_spec is False or by_spec is None:
++            return _orig_get_polygons(self, **kwargs)
++        dbu = self.kcl.dbu
++        per_spec = _orig_get_polygons(self, by="tuple")
++        if by_spec is True:
++            return {
++                spec: __v7_polys_um(polys, dbu) for spec, polys in per_spec.items()
++            }
++        return __v7_polys_um(per_spec.get(tuple(by_spec), []), dbu)
++
++    # noinspection PyPep8Naming
++    def __gf__ComponentReference__get_polygons_v7compat(self, by_spec=False, **kwargs):
++        cell = self.cell
++        ly = cell.kcl.layout
++        dbu = ly.dbu
++        inst_trans = self.dcplx_trans
++
++        def polys_for(spec):
++            li = ly.layer(kdb.LayerInfo(spec[0], spec[1]))
++            out = []
++            it = cell.kdb_cell.begin_shapes_rec(li)
++            while not it.at_end():
++                sh = it.shape()
++                if sh.is_polygon() or sh.is_box() or sh.is_path():
++                    dp = sh.polygon.transformed(it.trans()).to_dtype(dbu)
++                    dp = dp.transformed(inst_trans)
++                    out.append(
++                        _np.array([(pt.x, pt.y) for pt in dp.each_point_hull()])
++                    )
++                it.next()
++            return out
++
++        if by_spec is True:
++            result = {}
++            for li in ly.layer_indexes():
++                info = ly.get_info(li)
++                polys = polys_for((info.layer, info.datatype))
++                if polys:
++                    result[(info.layer, info.datatype)] = polys
++            return result
++        return polys_for(tuple(by_spec))
++
++    _patch_class_attr(
++        gf.Component, "get_polygons", __gf__Component__get_polygons_v7compat, force=True
++    )
++    _patch_class_attr(
++        gf.ComponentReference,
++        "get_polygons",
++        __gf__ComponentReference__get_polygons_v7compat,
++        force=True,
++    )
++
++    #
++    # Emulate the gdsfactory v7 ComponentReference.connect(port, destination=...)
++    # keyword. v7 did not enforce port width/layer/type compatibility, so v7-style
++    # calls also relax those checks (kfactory >= 2 raises on mismatch by default).
++    # Modern-style calls pass through unchanged.
++    #
++    _orig_connect = gf.ComponentReference.connect
++
++    # noinspection PyPep8Naming
++    def __gf__ComponentReference__connect_v7compat(
++        self, port, *args, destination=None, **kwargs
++    ):
++        if destination is not None:
++            kwargs.setdefault("allow_width_mismatch", True)
++            kwargs.setdefault("allow_layer_mismatch", True)
++            kwargs.setdefault("allow_type_mismatch", True)
++            return _orig_connect(self, port, destination, **kwargs)
++        return _orig_connect(self, port, *args, **kwargs)
++
++    _patch_class_attr(
++        gf.ComponentReference,
++        "connect",
++        __gf__ComponentReference__connect_v7compat,
++        force=True,
++    )
++
++    #
++    # gdsfactory >= 9.29 no longer auto-activates the generic PDK (the CONF.pdk
++    # default changed from "generic" to None). The drawing code relies on an active
++    # PDK for layer-tuple resolution in gf.Component.add_polygon(), so activate the
++    # generic PDK if none is active. On gdsfactory <= 9.28 get_active_pdk()
++    # auto-activates the generic PDK, making this a no-op there. A PDK activated by
++    # the user beforehand is never overridden.
++    #
+     try:
+         gf.get_active_pdk()
+     except ValueError:
+-        gf.gpdk.PDK.activate()
+-
+-
+-_activate_generic_pdk()
++        gf.gpdk.PDK.activate()
+\ No newline at end of file
+diff -ruN a/cells/cap_mim.py b/cells/cap_mim.py
+--- a/cells/cap_mim.py	2026-07-23 00:45:08.561450223 +0200
++++ b/cells/cap_mim.py	2026-07-23 00:45:08.574294389 +0200
+@@ -37,11 +37,11 @@
+         super(cap_mim, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("mim_option", self.TypeList, "MIM-Option")
++        self.Type_handle = self.param("mim_option", self.TypeList, "MIM-Option", default="MIM-A")
+         self.Type_handle.add_choice("MIM-A", "MIM-A")
+         self.Type_handle.add_choice("MIM-B", "MIM-B")
+ 
+-        self.Type_handle2 = self.param("metal_level", self.TypeList, "MIM_Metal_level")
++        self.Type_handle2 = self.param("metal_level", self.TypeList, "MIM_Metal_level", default="M3")
+         self.Type_handle2.add_choice("M2-M3", "M3")
+         self.Type_handle2.add_choice("M3-M4", "M4")
+         self.Type_handle2.add_choice("M4-M5", "M5")
+diff -ruN a/cells/cap_mos.py b/cells/cap_mos.py
+--- a/cells/cap_mos.py	2026-07-23 00:45:08.563722257 +0200
++++ b/cells/cap_mos.py	2026-07-23 00:45:08.576517757 +0200
+@@ -49,7 +49,7 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -137,7 +137,7 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -223,7 +223,7 @@
+         super(cap_nmos_b, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -309,7 +309,7 @@
+         super(cap_pmos_b, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+diff -ruN a/cells/diode.py b/cells/diode.py
+--- a/cells/diode.py	2026-07-23 00:45:08.562521886 +0200
++++ b/cells/diode.py	2026-07-23 00:45:08.575336511 +0200
+@@ -67,7 +67,7 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -160,7 +160,7 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -251,7 +251,7 @@
+         super(diode_nw2ps, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -341,7 +341,7 @@
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=1)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+@@ -433,7 +433,7 @@
+         super(diode_dw2ps, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+diff -ruN a/cells/fet.py b/cells/fet.py
+--- a/cells/fet.py	2026-07-23 00:45:08.565596209 +0200
++++ b/cells/fet.py	2026-07-23 00:45:08.577879253 +0200
+@@ -56,11 +56,11 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Deep NWELL Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Operating Voltage")
++        self.Type_handle = self.param("volt", self.TypeList, "Operating Voltage", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5V", "5V")
+         self.Type_handle.add_choice("6V", "6V")
+-        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type")
++        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type", default="None")
+         self.Type_handle.add_choice("None", "None")
+         self.Type_handle.add_choice("Bulk Tie", "Bulk Tie")
+         self.Type_handle.add_choice("Guard Ring", "Guard Ring")
+@@ -216,11 +216,11 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Deep NWELL Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Operating Voltage")
++        self.Type_handle = self.param("volt", self.TypeList, "Operating Voltage", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5V", "5V")
+         self.Type_handle.add_choice("6V", "6V")
+-        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type")
++        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type", default="None")
+         self.Type_handle.add_choice("None", "None")
+         self.Type_handle.add_choice("Bulk Tie", "Bulk Tie")
+         self.Type_handle.add_choice("Guard Ring", "Guard Ring")
+@@ -374,7 +374,7 @@
+         super(nfet_06v0_nvt, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type")
++        self.Type_handle = self.param("bulk", self.TypeList, "Bulk Type", default="None")
+         self.Type_handle.add_choice("None", "None")
+         self.Type_handle.add_choice("Bulk Tie", "Bulk Tie")
+         self.Type_handle.add_choice("Guard Ring", "Guard Ring")
+diff -ruN a/cells/res.py b/cells/res.py
+--- a/cells/res.py	2026-07-23 00:45:08.555786491 +0200
++++ b/cells/res.py	2026-07-23 00:45:08.569773613 +0200
+@@ -92,7 +92,7 @@
+         super(metal_resistor, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("res_type", self.TypeList, "Metal resistor type")
++        self.Type_handle = self.param("res_type", self.TypeList, "Metal resistor type", default="rm1")
+         self.Type_handle.add_choice("rm1", "rm1")
+         self.Type_handle.add_choice("rm2", "rm2")
+         self.Type_handle.add_choice("rm3", "rm3")
+@@ -1247,7 +1247,7 @@
+         # ===================== PARAMETERS DECLARATIONS =====================
+         self.param("deepnwell", self.TypeBoolean, "Deep NWELL", default=0)
+         self.param("pcmpgr", self.TypeBoolean, "Guard Ring", default=0)
+-        self.Type_handle = self.param("volt", self.TypeList, "Voltage area")
++        self.Type_handle = self.param("volt", self.TypeList, "Voltage area", default="3.3V")
+         self.Type_handle.add_choice("3.3V", "3.3V")
+         self.Type_handle.add_choice("5/6V", "5/6V")
+ 
+diff -ruN a/cells/via_generator.py b/cells/via_generator.py
+--- a/cells/via_generator.py	2026-07-23 00:45:08.556221198 +0200
++++ b/cells/via_generator.py	2026-07-23 00:45:08.570099528 +0200
+@@ -227,7 +227,7 @@
+ 
+ @gf.cell
+ def draw_via_dev(
+-    layout,
++    layout=None,
+     x_min: float = 0,
+     y_min: float = 0,
+     x_max: float = 2,
+diff -ruN a/cells/vias_gen.py b/cells/vias_gen.py
+--- a/cells/vias_gen.py	2026-07-23 00:45:08.564502213 +0200
++++ b/cells/vias_gen.py	2026-07-23 00:45:08.577442379 +0200
+@@ -36,7 +36,7 @@
+         super(via_dev, self).__init__()
+ 
+         # ===================== PARAMETERS DECLARATIONS =====================
+-        self.Type_handle = self.param("base_layer", self.TypeList, "start_layer")
++        self.Type_handle = self.param("base_layer", self.TypeList, "start_layer", default="poly2")
+         self.Type_handle.add_choice("poly2", "poly2")
+         self.Type_handle.add_choice("comp", "comp")
+         self.Type_handle.add_choice("M1", "M1")
+@@ -46,7 +46,7 @@
+         self.Type_handle.add_choice("M5", "M5")
+         self.Type_handle.add_choice("Mtop", "Mtop")
+ 
+-        self.Type_handle = self.param("metal_level", self.TypeList, "end_layer")
++        self.Type_handle = self.param("metal_level", self.TypeList, "end_layer", default="Mtop")
+         self.Type_handle.add_choice("poly2", "poly2")
+         self.Type_handle.add_choice("comp", "comp")
+         self.Type_handle.add_choice("M1", "M1")
+@@ -100,8 +100,6 @@
+     def produce_impl(self):
+ 
+         instance = draw_via_dev(
+-            "via_stack_dev",
+-            self.layout,
+             x_max=self.x_max,
+             y_max=self.y_max,
+             metal_level=self.metal_level,

--- a/_build/images/open_pdks/scripts/install_ciel.sh
+++ b/_build/images/open_pdks/scripts/install_ciel.sh
@@ -189,25 +189,19 @@ if [ -d "$PDK_ROOT/gf180mcuD" ]; then
 	find "$PDK_ROOT/gf180mcuD/libs.tech/xschem" -name "*.sym" \
 		-exec sed -i 's/msky130_fd_pr__@model/m0/g' {} \;
 
-	# gdsfactory >= 9.29 no longer auto-activates its generic PDK (the CONF.pdk
-	# default changed from "generic" to None), but the pcell drawing code relies
-	# on an active PDK for layer-tuple resolution in Component.add_polygon().
-	# Activate it once at import if no PDK is active (no-op on older versions,
-	# and it never overrides a PDK the user has activated themselves).
-	cat >> "$PDK_ROOT/gf180mcuD/libs.tech/klayout/tech/pymacros/cells/_patches.py" <<'PYEOF'
-
-
-def _activate_generic_pdk():
-    import gdsfactory as gf
-
-    try:
-        gf.get_active_pdk()
-    except ValueError:
-        gf.gpdk.PDK.activate()
-
-
-_activate_generic_pdk()
-PYEOF
+	# Port the bundled (gdsfactory v7 era) pcells to the current gdsfactory 9.x:
+	#  - cells/_patches.py (new): runtime shims for removed v7 APIs (add_array,
+	#    size, get_polygons(by_spec=...), connect(destination=...), geometry
+	#    namespace, duplicate cell names) plus explicit generic-PDK activation
+	#    (gdsfactory >= 9.29 no longer auto-activates it).
+	#  - explicit defaults for all TypeList pcell parameters (KLayout batch API
+	#    passes None otherwise, yielding silently empty pfet/via_dev devices).
+	#  - fix the draw_via_dev() call in vias_gen.py (stray v7-era arguments).
+	# See patches/gf180mcu-pcells-gdsfactory9.patch for the full change.
+	(
+		cd "$PDK_ROOT/gf180mcuD/libs.tech/klayout/tech/pymacros" || exit 1
+		git apply /images/open_pdks/patches/gf180mcu-pcells-gdsfactory9.patch
+	)
 
     # Give universal write access to the macro directory, necessary for saving options
     # and creating the run directory.


### PR DESCRIPTION
## What changed

- New `_build/images/open_pdks/patches/gf180mcu-pcells-gdsfactory9.patch` (443 lines, 9 files): ports the gf180mcu pcells bundled in the ciel/open_pdks PDK from the gdsfactory v7 API to the current system gdsfactory (9.46.0 / kfactory 3.0.2).
- `install_ciel.sh`: the previous `cat >> _patches.py` activation append (dead code since the switch away from the martinjankoehler fork — these pcells never import `_patches`) is replaced by `git apply` of the new patch inside the pymacros directory.

## Patch contents

1. **`cells/_patches.py` (new) + import hook in `cells/__init__.py`** — runtime shims for the removed v7 APIs used by the drawing code: `Component.add_array`, `size`, the `gf.geometry` namespace, `get_polygons(by_spec=True)` and `get_polygons(by_spec=(layer, datatype))` on components *and* references (v7-style µm numpy arrays), `connect(destination=...)` with relaxed port width/layer/type checks, `KCLayout.create_cell(allow_duplicate=True)`, and explicit generic-PDK activation (gdsfactory ≥ 9.29 no longer auto-activates it; guarded, never overrides a user-activated PDK).
2. **Explicit `default=` for all 20 TypeList pcell parameters** — KLayout's batch API passes `None` for TypeList parameters without defaults (the GUI masks this by preselecting the first choice). This was the root cause of the long-standing *silent* empty pfet/via_dev cells in scripted use, and affected the former fork-based pcells as well.
3. **`vias_gen.py`** — remove stray v7-era positional arguments in the `draw_via_dev()` call (they shifted the `Layout` object into `x_min`); `via_dev`'s `metal_level` now defaults to `Mtop` so the default parameter set is non-degenerate.

## Verification

In `hpretl/iic-osic-tools:next` (gdsfactory 9.46.0, kfactory 3.0.2, KLayout 0.30.9), applying the patch exactly as `install_ciel.sh` does and driving the real `klayout -b`:

- **29/29** registered pcells generate geometry with default parameters — better than the fork-based setup ever achieved (27/29; pfet and via_dev were always silently empty in batch mode).
- **198/199** variants of a full parameter sweep (every enum choice, scaled geometries, multi-finger/guard-ring/deep-nwell FET combos) generate geometry; the single exception (`cap_mim` MIM-B) has never produced geometry in any configuration.
- Per-layer area cross-check against the former fork-based baseline: identical or within 5 nm grid snapping, except (a) default-variant changes caused by the fixed enum defaults (now matching what the GUI produces) and (b) upstream nwell/lvpwell enclosure enlargements on the deep-well diodes that come with GF's newer sources.

## Reviewer notes

- The martinjankoehler fork is retired; this PR carries its compatibility-shim approach forward on top of the ciel-original sources, so no external clone remains in the build.
- The patch is maintained as a plain unified diff — when the upstream PDK bundle changes, `git apply` will fail loudly at build time rather than silently misapplying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)