### PR TITLE
enable xschem "analyses" visual simulation-setup library (better solution for PR #303)

### DIFF
--- a/_build/images/base/skel/etc/profile.d/iic-osic-tools-setup.sh
+++ b/_build/images/base/skel/etc/profile.d/iic-osic-tools-setup.sh
@@ -136,18 +136,3 @@ if [ -n "${DESIGNS}" ] && [ -f "$DESIGNS/.designinit" ]; then
     # shellcheck source=/dev/null
     source "$DESIGNS/.designinit"
 fi
-
-# Always make the (PDK-independent) VACASK analyses symbols available in the xschem
-# symbol browser, from any working directory. This runs after .designinit so it adds
-# to any XSCHEM_USER_LIBRARY_PATH the user set there instead of overwriting it. The
-# analyses path is prepended so it sorts ahead of the user's project-specific paths.
-# The PDK xschemrc appends XSCHEM_USER_LIBRARY_PATH to XSCHEM_LIBRARY_PATH, so this
-# also works in project folders that ship their own xschemrc. The case statement skips
-# the change when the path is already present, so a re-sourced login shell does not
-# add a duplicate.
-_iic_analyses_lib="${TOOLS}/xschem/share/doc/xschem/analyses"
-case ":${XSCHEM_USER_LIBRARY_PATH}:" in
-    *":${_iic_analyses_lib}:"*) ;;
-    *) export XSCHEM_USER_LIBRARY_PATH="${_iic_analyses_lib}${XSCHEM_USER_LIBRARY_PATH:+:${XSCHEM_USER_LIBRARY_PATH}}" ;;
-esac
-unset _iic_analyses_lib

--- a/_build/images/xschem/scripts/install.sh
+++ b/_build/images/xschem/scripts/install.sh
@@ -13,4 +13,33 @@ git checkout "${XSCHEM_REPO_COMMIT}"
 make -j"$(nproc)"
 make install
 
+# Enable the "analyses" symbol library that ships with xschem, so VACASK and ngspice
+# simulations can be set up visually (op, ac, tran, sweep, command_block, ...) instead
+# of by hand-writing a control block. The library is PDK-independent, so it is enabled
+# in the system-wide xschemrc: that file is always sourced, and it is sourced before
+# any project, user, or PDK xschemrc. Both steps run in postinit_commands because the
+# PDK xschemrc files reset XSCHEM_LIBRARY_PATH to {} when they are sourced later during
+# startup, which would drop a path appended here. Sourcing lib_init.tcl is required as
+# well: it defines the procs that render the symbols and netlist the control block.
+# See https://codeberg.org/arpadbuermen/VACASK/src/branch/main/demo/xschem for details.
+cat >> "${TOOLS}/${XSCHEM_NAME}/share/xschem/xschemrc" <<'EOF'
+
+###########################################################################
+#### VISUAL ANALYSIS SETUP LIBRARY (VACASK AND NGSPICE)
+###########################################################################
+append postinit_commands {
+  set iic_analyses_dir [file normalize ${XSCHEM_SHAREDIR}/../doc/xschem/analyses]
+  if {[file isdirectory $iic_analyses_dir] && [lsearch -exact $pathlist $iic_analyses_dir] < 0} {
+    # Writing XSCHEM_LIBRARY_PATH refreshes pathlist through a variable trace.
+    append XSCHEM_LIBRARY_PATH :$iic_analyses_dir
+  }
+  unset iic_analyses_dir
+  foreach i $pathlist {
+    if {![catch {source $i/lib_init.tcl} retval]} {
+      puts "Sourced library init file $i/lib_init.tcl"
+    }
+  }
+}
+EOF
+
 echo "${XSCHEM_NAME} ${XSCHEM_REPO_COMMIT}" > "${TOOLS}/${XSCHEM_NAME}/SOURCES"


### PR DESCRIPTION
### What

Makes the `analyses` symbol library that ships with xschem (op, ac, tran, sweep, command_block, ...) available out of the box, so VACASK and ngspice simulations can be set up visually instead of by hand-writing a control block.

This is done in xschem's **system-wide** `xschemrc` (`$TOOLS/xschem/share/xschem/xschemrc`), populated during the build in `_build/images/xschem/scripts/install.sh`.

### Reverts #303

PR #303 enabled the same symbols by exporting `XSCHEM_USER_LIBRARY_PATH` from
`_build/images/base/skel/etc/profile.d/iic-osic-tools-setup.sh`. That block is **reverted** here, because that approach had two problems:

1. **It only worked for the IHP PDK.** xschem never reads library paths from the environment — `XSCHEM_LIBRARY_PATH` is a plain Tcl variable. The env var only takes effect if the PDK's `xschemrc` explicitly appends it. The IHP sg13g2 `xschemrc` does; the sky130 `xschemrc` (installed by open_pdks) does not, so the symbols never appeared there.
2. **The path alone is not enough.** The analyses library requires its `lib_init.tcl` to be sourced — it defines the Tcl procs that render the symbols and netlist the control block. Without it the symbols show up in the browser but are broken when placed. xschem does not auto-source `lib_init.tcl`.

### Approach

The snippet is appended to the system-wide `xschemrc`, which xschem always sources **before** any project, user, or PDK `xschemrc`. It works for every PDK with no dependence on the PDK `xschemrc` cooperating, and it actually makes the blocks functional rather than merely visible.

Both the path append and the `lib_init.tcl` sourcing run inside `postinit_commands` because the PDK `xschemrc` files reset `XSCHEM_LIBRARY_PATH` to `{}` when sourced later during startup, which would otherwise drop a path added earlier. Writing `XSCHEM_LIBRARY_PATH` refreshes `pathlist` through xschem's variable trace, and `postinit_commands` run after that trace is installed, so the `foreach` picks up the new path. An `lsearch` guard keeps it idempotent. This follows the upstream VACASK recommendation (Thanks @arpadbuermen): https://codeberg.org/arpadbuermen/VACASK/src/branch/main/demo/xschem