### PR TITLE
updated `test_sparx_sg13g2.sh`: added `SIM_WRAP="xvfb-run -a"` as for `test_sparx_sg13g2.sh`

### DIFF
--- a/_tests/22/test_sparx_sg13g2.sh
+++ b/_tests/22/test_sparx_sg13g2.sh
@@ -45,9 +45,14 @@ git config --global --add safe.directory "$TMP/$REPO"
 # shellcheck source=/dev/null
 source sak-pdk-script.sh ihp-sg13g2 > /dev/null
 
-# Run the regression target and check the result
+# Run the regression target and check the result.
+# With DEBUG=1, run interactively so the ngspice/xschem plots are shown. 
+# Otherwise, run headless under a throwaway virtual X server (xvfb-run) so no plot windows pop up.
+SIM_WRAP="xvfb-run -a"
+[ "$DEBUG" = 1 ] && SIM_WRAP=""
 [ "$DEBUG" = 1 ] && echo "[INFO] Running 'make regression' (output is logged to $LOG) ..."
-if make regression >> "$LOG" 2>&1; then
+# shellcheck disable=SC2086
+if $SIM_WRAP make regression >> "$LOG" 2>&1; then
     echo "[INFO] Test <SPARX with ihp-sg13g2> passed."
     exit 0
 else


### PR DESCRIPTION
Run the regression target and check the result. With DEBUG=1, run interactively so the ngspice/xschem plots are shown. Otherwise, run headless under a throwaway virtual X server (xvfb-run), so no plot windows pop up.