### PR TITLE
added regression test of TinyWhisper with ihp-sg13g2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ IIC-OSIC-TOOLS is a comprehensive Docker/Podman-based container distribution for
 
 **Key directories:**
 - `_build/`: Multi-stage Docker build system with tool images and build orchestration
-- `_tests/`: Regression test suite (26 tests covering PDKs, tools, and workflows)
+- `_tests/`: Regression test suite (28 tests covering PDKs, tools, and workflows)
 - Root scripts: Container startup scripts for VNC, X11, Jupyter, and shell modes
 
 ## Architecture & Build System

--- a/_tests/28/test_tinywhisper_sg13g2.sh
+++ b/_tests/28/test_tinywhisper_sg13g2.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Simon Dorrer
+# Johannes Kepler University, Department for Integrated Circuits
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression test based on the TinyWhisper multi-mode short-wave transmitter
+# of <https://github.com/iic-jku/TinyWhisper>.
+#
+# It clones the repository (incl. submodules) and runs the `make regression`
+# target of the ihp130 design variant, exercising the digital and analog
+# design flow of the chip (LibreLane, DRC/LVS verification, and xschem/
+# ngspice and cocotb simulations) with the IHP SG13G2 PDK.
+
+if [ -z "${RAND}" ]; then
+    RAND=$(hexdump -e '/1 "%02x"' -n4 < /dev/urandom)
+fi
+
+# test output is kept out of the bind-mounted source tree (see run_docker_tests.sh)
+RUNS_DIR=${IIC_TEST_RUNDIR:-/tmp/iic-osic-tools-tests}
+
+DEBUG=${DEBUG:-0}
+
+TMP=${RUNS_DIR}/${RAND}/28
+LOG=$TMP/tinywhisper_sg13g2.log
+REPO=TinyWhisper
+
+mkdir -p "$TMP"
+cd "$TMP" || exit 1
+
+# Clone the main branch of the TinyWhisper repository (incl. submodules)
+[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (main branch, incl. submodules) ..."
+if ! git clone --recursive --branch main \
+        https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
+    echo "[ERROR] Test <TinyWhisper with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
+    exit 1
+fi
+cd "$REPO" || exit 1
+
+# Allow git to operate on this repo even if the dir owner differs from the
+# container user (avoids "detected dubious ownership")
+git config --global --add safe.directory "$TMP/$REPO"
+
+# Switch to the ihp-sg13g2 PDK (sets PDK and PDK_ROOT, loads the OSDI models)
+[ "$DEBUG" = 1 ] && echo "[INFO] Switching to the ihp-sg13g2 PDK ..."
+# shellcheck source=/dev/null
+source sak-pdk-script.sh ihp-sg13g2 > /dev/null
+
+# Run the regression target of the ihp130 design variant and check the result.
+# With DEBUG=1, run interactively so the ngspice/xschem plots are shown.
+# Otherwise, run headless under a throwaway virtual X server (xvfb-run) so no plot windows pop up.
+cd ihp130 || exit 1
+SIM_WRAP="xvfb-run -a"
+[ "$DEBUG" = 1 ] && SIM_WRAP=""
+[ "$DEBUG" = 1 ] && echo "[INFO] Running 'make regression' (output is logged to $LOG) ..."
+# shellcheck disable=SC2086
+if $SIM_WRAP make regression >> "$LOG" 2>&1; then
+    echo "[INFO] Test <TinyWhisper with ihp-sg13g2> passed."
+    exit 0
+else
+    echo "[ERROR] Test <TinyWhisper with ihp-sg13g2> FAILED! Check the log file $LOG for details."
+    exit 1
+fi

--- a/_tests/TESTS.md
+++ b/_tests/TESTS.md
@@ -41,3 +41,4 @@ IIC_TEST_RUNDIR=/mnt/scratch/osic-tests ./run_docker_tests.sh hpretl/iic-osic-to
 | 25       | Smoke/regression test of sak-pex.sh (all PDKs and PEX modes)                                                                    |
 | 26       | [open-pdks regression tests](https://github.com/iic-jku/open-pdks-regression-tests) (LVS, DRC, PEX) with ihp-sg13g2             |
 | 27       | KLayout PCells smoke/regression test (instantiate all PCells of all PDKs, flag empty cells and errors)                          |
+| 28       | [TinyWhisper](https://github.com/iic-jku/TinyWhisper) multi-mode short-wave transmitter with ihp-sg13g2                         |


### PR DESCRIPTION
I implemented a regression test of [TinyWhisper](https://github.com/iic-jku/TinyWhisper) with ihp-sg13g2 for the IIC-OSIC-TOOLS. I added test 28. The script is called `test_tinywhisper_sg13g2.sh`. I updated `TESTS.md` and `copilot-instructions.md` accordingly.