### PR TITLE
sak-pin-reorder.py: match the .subckt card case-insensitively

### DIFF
--- a/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pin-reorder.py
+++ b/_build/images/iic-osic-tools/skel/foss/tools/sak/sak-pin-reorder.py
@@ -148,16 +148,24 @@ def parse_sym_pins(sym_path: str) -> list[tuple[str, str | None]]:
     return pins
 
 
-def parse_subckt_from_lines(lines: list[str]) -> tuple[str, list[str], int, int]:
+def parse_subckt_from_lines(
+    lines: list[str],
+) -> tuple[str, list[str], int, int, str]:
     """Extract the subcircuit name and pin list from the first .subckt in lines.
 
+    SPICE cards are case-insensitive and netlisters disagree: xschem and
+    Magic write ``.subckt``, KLayout-PEX writes ``.SUBCKT``. The card is
+    therefore matched case-insensitively and its original spelling is
+    returned so the rewritten header keeps the file's own style.
+
     Handles continuation lines starting with '+'.
-    Returns (subckt_name, pin_list, first_line_index, last_line_index).
+    Returns (subckt_name, pin_list, first_line_index, last_line_index, keyword).
     """
     for i, line in enumerate(lines):
         stripped = line.strip()
-        if stripped.startswith('.subckt'):
+        if stripped[:7].lower() == '.subckt':
             parts = stripped.split()
+            keyword = parts[0]
             subckt_name = parts[1]
             pins = parts[2:]
             last = i
@@ -168,7 +176,7 @@ def parse_subckt_from_lines(lines: list[str]) -> tuple[str, list[str], int, int]
                     last = j
                 else:
                     break
-            return subckt_name, pins, i, last
+            return subckt_name, pins, i, last, keyword
     raise ValueError("No .subckt line found in the netlist file")
 
 
@@ -294,7 +302,7 @@ def reconcile_scalar_buses(
         token_pattern.sub(lambda m: rename[m.group(1)], ln)
         for ln in lines
     ]
-    _, new_netlist_pins, _, _ = parse_subckt_from_lines(new_lines)
+    _, new_netlist_pins, _, _, _ = parse_subckt_from_lines(new_lines)
     return new_lines, new_netlist_pins, sorted(rename.items())
 
 
@@ -330,11 +338,15 @@ def rewrite_subckt_header(
     ordered_pins: list[str],
     first_idx: int,
     last_idx: int,
+    keyword: str = '.subckt',
 ) -> list[str]:
     """Return a copy of ``lines`` with the .subckt header replaced by one
-    listing ``ordered_pins``, wrapped to ~80 columns with '+' continuations."""
+    listing ``ordered_pins``, wrapped to ~80 columns with '+' continuations.
+
+    ``keyword`` is the card as spelled in the source file, so a netlist
+    written with ``.SUBCKT`` keeps its case."""
     max_width = 80
-    header = f".subckt {subckt_name}"
+    header = f"{keyword} {subckt_name}"
     subckt_lines = []
     current = header
     for pin in ordered_pins:
@@ -366,7 +378,7 @@ def main():
     sym_pins = parse_sym_pins(args.sym_file)
     with open(args.netlist_file, 'r') as f:
         lines = f.readlines()
-    subckt_name, netlist_pins, _, _ = parse_subckt_from_lines(lines)
+    subckt_name, netlist_pins, _, _, _ = parse_subckt_from_lines(lines)
 
     fmt = args.format
     if fmt == "auto":
@@ -418,9 +430,9 @@ def main():
         print(f"  {sp:25s} -> {np:25s}{marker}")
 
     # 4. Reorder subckt header and write back
-    _, _, first_idx, last_idx = parse_subckt_from_lines(lines)
+    _, _, first_idx, last_idx, keyword = parse_subckt_from_lines(lines)
     lines = rewrite_subckt_header(lines, subckt_name, ordered_netlist,
-                                  first_idx, last_idx)
+                                  first_idx, last_idx, keyword)
     with open(output_path, 'w') as f:
         f.writelines(lines)
 


### PR DESCRIPTION
## Problem

`sak-pin-reorder.py` matched the subcircuit card with
`stripped.startswith('.subckt')`, i.e. lowercase only.

SPICE cards are case-insensitive and netlisters disagree on the spelling:
xschem and Magic write `.subckt`, but **KLayout-PEX (kpex) writes `.SUBCKT`**.
So every kpex-extracted netlist -- the main thing you would want to reorder
before dropping it into an xschem testbench -- failed on a perfectly
well-formed file:

```
$ sak-pin-reorder.py tspc_dff.sym tspc_dff_pex.spice
[ERROR] No .subckt line found in the netlist file
```

```
*** NGSPICE file created by KLayout-PEX 0.3.12
.SUBCKT tspc_dff CLK D Q QB VDD VSS
```

The `.model` detection in `XSPICE_MODEL_PATTERN` already used `re.IGNORECASE`,
so the `.subckt` match was the odd one out.

## Fix

- `parse_subckt_from_lines()` matches the card case-insensitively.
- It additionally returns the keyword **as spelled in the source file**, which
  `rewrite_subckt_header()` uses for the new header. A `.SUBCKT` netlist stays
  `.SUBCKT`, so the diff against the extractor output stays limited to the port
  list and does not churn the card style.

## Testing

Verified in `hpretl/iic-osic-tools:2026.07`, patched vs. stock:

| Case | Result |
|---|---|
| Real kpex `.SUBCKT` netlist (IHP SG13, `tspc_dff`) | now succeeds; only the header line differs from the input, case preserved |
| Same netlist lowercased | unchanged behaviour |
| Bus expansion `cnt_o[3..0]` + `sim_pinnumber` | byte-identical to stock |
| Scalar to bus-of-one reconcile (`X` to `X[0]`) | byte-identical to stock |
| XSPICE auto-detect + `sim_pinname` name mode | byte-identical to stock |
| XSPICE positional fallback (`VDD` / `a_VPWR`) | byte-identical to stock |
| Errors: pin-count / pin-set mismatch, `sim_pinname` not 1:1, power-pin mismatch, no `.subckt` at all | still exit 1, input left untouched |
| Re-run on an already-reordered `.SUBCKT` file | idempotent |

## Note

No `RELEASE_NOTES.md` entry included, to avoid colliding with the entries
currently in flight on `next_release` -- happy to add one if you prefer.