### PR TITLE
added hot-fix for snp2le and chipify

### DIFF
--- a/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
+++ b/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
@@ -75,11 +75,27 @@ pip3 install $PIP_FLAGS \
 # only use QtWidgets/QtCore/QtGui/QtSvg, all of which live in
 # PySide6-Essentials. The PySide6-Addons half (~340 MB, dominated by a 254 MB
 # embedded Chromium in QtWebEngine, plus Qt3D/Quick3D/Designer/Multimedia) is
-# not imported by anything in the image, so remove it. Essentials stays, so
-# the GUIs keep working; pip check will note the PySide6 meta-package wants
-# Addons, which is harmless at runtime.
+# not imported by anything in the image, so remove it.
+#
+# Catch: the Essentials and Addons wheels BOTH ship the shared top-level PySide6
+# files (PySide6/__init__.py, _config.py, __feature__.py, _git_pyside_version.py),
+# and pip does no cross-package refcounting -- so "pip uninstall PySide6-Addons"
+# also deletes the PySide6/__init__.py that Essentials still needs. That leaves
+# PySide6 importable only as a namespace package with no __version__, which breaks
+# matplotlib's Qt backend ("cannot import name '__version__' from 'PySide6'") and
+# every GUI built on it. So force-reinstall Essentials afterwards to rewrite the
+# shared files (--no-deps stops Addons from being pulled back in).
+#
+# The PySide6 meta-package is kept on purpose: gds2palace and setupEM depend on it
+# by name, so removing it would leave their dependency unsatisfied. pip check will
+# note the meta-package wants Addons, which is harmless at runtime.
 echo "[INFO] Removing unused PySide6-Addons (QtWebEngine, Qt3D, ...)"
+# Pin the reinstall to the version already resolved above, so it cannot pull a
+# newer PySide6-Essentials that mismatches the installed shiboken6.
+PYSIDE6_VER=$(pip3 show PySide6-Essentials | awk '/^Version:/{print $2}')
+[ -n "$PYSIDE6_VER" ] || { echo "[ERROR] PySide6-Essentials not installed"; exit 1; }
 pip3 uninstall -y --break-system-packages PySide6-Addons
+pip3 install $PIP_FLAGS --no-deps --force-reinstall "PySide6-Essentials==${PYSIDE6_VER}"
 
 echo "[INFO] Install EDA packages via Cargo"
 


### PR DESCRIPTION
## Problem

In the `2026.07` image, `snp2le` and `chipify` crash on launch:

```
File ".../matplotlib/backends/qt_compat.py", line 79, in _setup_pyqt5plus
    from PySide6 import QtCore, QtGui, QtWidgets, QtSvg, __version__
ImportError: cannot import name '__version__' from 'PySide6' (unknown location)
```

`(unknown location)` is the tell: `PySide6` has degraded to an implicit **namespace package** because `PySide6/__init__.py` is missing, so `__version__` — defined only there — no longer exists. matplotlib's Qt backend needs it, so every GUI built on that backend fails.

## Root cause

`install_eda.sh` removes the unused `PySide6-Addons` (~340 MB, mostly the embedded Chromium in QtWebEngine) to slim the image:

```sh
pip3 uninstall -y --break-system-packages PySide6-Addons
```

But the **Essentials and Addons wheels both ship the shared top-level files** — `PySide6/__init__.py`, `_config.py`, `__feature__.py`, `_git_pyside_version.py`. pip does no cross-package reference counting, so uninstalling Addons **also deletes the `PySide6/__init__.py` that Essentials still needs**. Essentials' own `RECORD` still lists the file, but it is gone from disk.

The build's CLI-only smoke test missed it because the CLI path never imports the Qt backend.

## Fix

Force-reinstall Essentials after removing Addons, to rewrite the shared files:

```sh
PYSIDE6_VER=$(pip3 show PySide6-Essentials | awk '/^Version:/{print $2}')
[ -n "$PYSIDE6_VER" ] || { echo "[ERROR] PySide6-Essentials not installed"; exit 1; }
pip3 uninstall -y --break-system-packages PySide6-Addons
pip3 install $PIP_FLAGS --no-deps --force-reinstall "PySide6-Essentials==${PYSIDE6_VER}"
```

- `--no-deps` stops Addons from being pulled back in.
- **Pinned** to the already-resolved version, so the reinstall cannot drift to a newer Essentials that mismatches the installed `shiboken6`.
- Uses the script's `$PIP_FLAGS` so `--no-cache-dir` applies — without it the re-downloaded ~80 MB wheel would be baked into this `RUN` layer (nothing purges the pip cache), cancelling part of the saving.
- Guard on the empty version, since `set -e` does not catch a failing `pip3 show` inside a pipeline.
- The `PySide6` meta-package is **kept on purpose**: `gds2palace` and `setupEM` depend on it by name, so removing it only trades one cosmetic `pip check` note for two unsatisfied deps.

## Verification

Reproduced the break in a running `2026.07` container, then applied the exact patched sequence:

| Check | Result |
|---|---|
| `PySide6.__version__` | `6.11.1 @ .../PySide6/__init__.py` restored |
| Essentials `RECORD` integrity | **2518/2518** files present, 0 missing |
| `snp2le` GUI | `MainWindow` constructs and shows |
| `chipify` Qt canvas | imports |
| Addons binaries on disk | none — no QtWebEngine/Qt3D/Charts/Multimedia |
| PySide6 footprint | **232 MB** (vs ~634 MB full PySide6) — saving preserved |
| pip cache left in layer | none |
| `pip check` | only the harmless `pyside6 requires pyside6-addons` |
| `bash -n install_eda.sh` | passes |

Affected tools were `snp2le` and `chipify` (both import matplotlib's Qt backend); `gds2palace` and `setupEM` do not and were unaffected.

## Follow-ups (not in this PR)

- The image must be **rebuilt** to ship this; running containers are unaffected.
- **Separate, pre-existing bug:** with PyQt5/PyQt6 (apt) and PySide6 both installed, importing PyQt6 first makes PySide6 fail with `libpyside6.abi3.so.6.11: undefined symbol: _ZN9QtPrivate9sizedFreeEPvm` — an ABI clash between the apt Qt6 and the wheel's bundled Qt 6.11. Modules that import matplotlib's Qt backend *before* PySide6 (e.g. `chipify/gui_qt/widgets/mpl_canvas.py`) only work because the app imports PySide6 first. Setting `QT_API=PySide6` image-wide would make this deterministic; related to the `qt5_removal` work.
- Suggest a **GUI-import smoke test** in the build (`QT_QPA_PLATFORM=offscreen python3 -c "import snp2le.gui.main_window"`) so this class of breakage fails the build instead of shipping.
- Longer term, having `gds2palace`/`setupEM` declare `PySide6-Essentials` (as `snp2le` 0.1.5 does) would let the image install Essentials directly and drop the uninstall/reinstall dance.