### PR TITLE
fix(install_eda): stop the pip download cache leaking into the image (-55 MB)

### DIFF
--- a/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
+++ b/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
@@ -75,11 +75,27 @@ pip3 install $PIP_FLAGS \
 # only use QtWidgets/QtCore/QtGui/QtSvg, all of which live in
 # PySide6-Essentials. The PySide6-Addons half (~340 MB, dominated by a 254 MB
 # embedded Chromium in QtWebEngine, plus Qt3D/Quick3D/Designer/Multimedia) is
-# not imported by anything in the image, so remove it. Essentials stays, so
-# the GUIs keep working; pip check will note the PySide6 meta-package wants
-# Addons, which is harmless at runtime.
+# not imported by anything in the image, so remove it.
+#
+# Catch: the Essentials and Addons wheels BOTH ship the shared top-level PySide6
+# files (PySide6/__init__.py, _config.py, __feature__.py, _git_pyside_version.py),
+# and pip does no cross-package refcounting -- so "pip uninstall PySide6-Addons"
+# also deletes the PySide6/__init__.py that Essentials still needs. That leaves
+# PySide6 importable only as a namespace package with no __version__, which breaks
+# matplotlib's Qt backend ("cannot import name '__version__' from 'PySide6'") and
+# every GUI built on it. So force-reinstall Essentials afterwards to rewrite the
+# shared files (--no-deps stops Addons from being pulled back in).
+#
+# The PySide6 meta-package is kept on purpose: gds2palace and setupEM depend on it
+# by name, so removing it would leave their dependency unsatisfied. pip check will
+# note the meta-package wants Addons, which is harmless at runtime.
 echo "[INFO] Removing unused PySide6-Addons (QtWebEngine, Qt3D, ...)"
+# Pin the reinstall to the version already resolved above, so it cannot pull a
+# newer PySide6-Essentials that mismatches the installed shiboken6.
+PYSIDE6_VER=$(pip3 show PySide6-Essentials | awk '/^Version:/{print $2}')
+[ -n "$PYSIDE6_VER" ] || { echo "[ERROR] PySide6-Essentials not installed"; exit 1; }
 pip3 uninstall -y --break-system-packages PySide6-Addons
+pip3 install $PIP_FLAGS --no-deps --force-reinstall "PySide6-Essentials==${PYSIDE6_VER}"
 
 echo "[INFO] Install EDA packages via Cargo"
 

--- a/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
+++ b/_build/images/iic-osic-tools/skel/headless/scripts/install_eda.sh
@@ -13,6 +13,20 @@ set -e
 # Linux-aarch64 wheel, so a forced PyPI reinstall would fail on arm64
 PIP_FLAGS="--upgrade --no-cache-dir --break-system-packages"
 
+# Nothing below reads PIP_NO_CACHE_DIR -- pip itself does: every pip option has
+# a PIP_<OPTION> environment variable equivalent, so this is the same as adding
+# --no-cache-dir to every pip run, including ones this script never spells out.
+#
+# That is the point, because the flag in PIP_FLAGS only covers the outer pip.
+# It is not always handed down to the nested pip that PEP 517 build isolation
+# runs to fetch a package's build dependencies. The venvs below are the clearest
+# case: "python3 -m venv" bootstraps the pip bundled with CPython (24.0), which
+# does not forward the flag, so building the git+ packages pulls setuptools,
+# virtualenv, distlib, dulwich, numpy, ... straight into $HOME/.cache/pip. With
+# HOME=/headless during the build that left ~55 MB of download residue in the
+# image. An environment variable IS inherited by those nested invocations.
+export PIP_NO_CACHE_DIR=1
+
 echo "[INFO] Install EDA packages via APT"
 apt-get update
 apt-get install -y \
@@ -150,3 +164,10 @@ echo "[INFO] Removing bundled Python package test suites"
 find /usr/local/lib/python3*/dist-packages \
 	/foss/tools/charlib/lib /foss/tools/vlsirtools/lib \
 	-type d \( -name tests -o -name test \) -prune -exec rm -rf {} +
+
+# Belt and braces: PIP_NO_CACHE_DIR above should keep this empty, but a tool
+# invoking pip with its own environment could still populate it, and the cache
+# is pure build residue that must not reach the image. HOME is /headless for
+# the whole build, so that is the only cache pip can write.
+echo "[INFO] Removing pip download cache"
+rm -rf "${HOME:-/headless}/.cache/pip"

--- a/_tests/03/pkgs.py
+++ b/_tests/03/pkgs.py
@@ -19,3 +19,15 @@ import skrf
 import siliconcompiler
 import spicelib
 import spyci
+
+# The Qt GUIs (chipify, snp2le) reach matplotlib's qtagg backend, which needs
+# PySide6.__version__ from PySide6/__init__.py. That file is shared between
+# PySide6-Essentials, PySide6-Addons and the PySide6 meta-package, and the
+# image uninstalls Addons -- so check it and import the GUI entry points to
+# catch a PySide6 installation that got gutted by that uninstall.
+import PySide6
+
+assert PySide6.__version__, "PySide6/__init__.py missing (PySide6-Addons uninstall?)"
+
+import chipify.gui_qt.app  # noqa: E402,F401
+import snp2le.app  # noqa: E402,F401

--- a/_tests/03/pyside6_files.py
+++ b/_tests/03/pyside6_files.py
@@ -1,0 +1,42 @@
+# The image uninstalls PySide6-Addons to save ~340 MB (QtWebEngine, Qt3D, ...).
+# The Essentials, Addons and meta-package wheels all ship the same top-level
+# PySide6 files (__init__.py, _config.py, _git_pyside_version.py, the .pyi
+# stubs), and pip does no cross-package refcounting -- so that uninstall
+# happily deletes files the remaining packages still own. Check that every
+# file the installed PySide6 distributions claim is actually on disk, which
+# catches the whole class of "pip uninstall gutted a sibling wheel" breakage
+# rather than just the symptom it produced in chipify/snp2le.
+
+import csv
+import sys
+from importlib.metadata import distributions
+from pathlib import Path
+
+missing = {}
+
+for dist in distributions():
+    name = dist.metadata["Name"] or ""
+    if not name.lower().startswith("pyside6"):
+        continue
+    record = dist.read_text("RECORD")
+    if record is None:
+        print(f"[WARNING] {name}: no RECORD, cannot verify")
+        continue
+    root = Path(dist.locate_file(""))
+    gone = [
+        row[0]
+        for row in csv.reader(record.splitlines())
+        if row and not (root / row[0]).exists()
+    ]
+    if gone:
+        missing[f"{name} {dist.version}"] = gone
+
+for dist, gone in missing.items():
+    print(f"[ERROR] {dist}: {len(gone)} installed file(s) missing, e.g.:")
+    for path in gone[:5]:
+        print(f"          {path}")
+
+if missing:
+    sys.exit(1)
+
+print("[INFO] All installed PySide6 distributions are complete on disk.")

--- a/_tests/03/test_python_pkgs.sh
+++ b/_tests/03/test_python_pkgs.sh
@@ -16,6 +16,14 @@ else
     echo "[INFO] Test <Loading Python-packages> passed."
 fi
 
+if ! python "$DIR/pyside6_files.py"
+then
+    echo "[ERROR] Test <PySide6 installation complete> FAILED."
+    ERR=1
+else
+    echo "[INFO] Test <PySide6 installation complete> passed."
+fi
+
 if ! /foss/tools/charlib/bin/python -c "import charlib"
 then
     echo "[ERROR] Test <Loading charlib> FAILED."


### PR DESCRIPTION
## Problem

The shipped image carries **55 MB of pip download cache** at `/headless/.cache/pip` — 340 files of pure build residue (`pip cache info`: 54.0 MB index cache, 0 locally built wheels). Nothing uses it at runtime.

## Root cause

Every `pip3 install` in `install_eda.sh` already passes `--no-cache-dir`, which makes this look impossible. The leak is in **nested** pip invocations, not the outer ones.

`python3 -m venv` bootstraps the pip bundled with CPython — **pip 24.0** — and that pip does **not** forward `--no-cache-dir` to the nested pip it runs for PEP 517 build isolation. So building the two `git+` packages (CharLib, Hdl21) downloads their build dependencies straight into `$HOME/.cache/pip`. With `HOME=/headless` set image-wide, that residue ends up in the image.

The cached artifacts match exactly — `virtualenv`, `distlib`, `dulwich`, `installer`, `rapidfuzz`, `setuptools`, `babel`, `cryptography`, `numpy-1.26.2` — build-backend dependencies, not runtime packages.

## Fix

```sh
export PIP_NO_CACHE_DIR=1
```

Nothing in the script reads this variable — **pip does**. Every pip option has a `PIP_<OPTION>` environment-variable equivalent, so this is the same as adding `--no-cache-dir` to every pip run, including the nested ones the script never spells out. Unlike the command-line flag, an environment variable *is* inherited by those subprocesses.

It is script-scoped, so it does **not** persist into the image environment — end users keep their pip cache at runtime.

A `rm -rf "${HOME:-/headless}/.cache/pip"` is added to the script's existing cleanup section as a guarantee, in case a tool invokes pip with its own environment.

## Verification

All checked in a `2026.07` container:

- **pip honours the variable** — `pip config debug` reports `PIP_NO_CACHE_DIR='1'`; `pip cache dir` then reports the cache disabled.
- **The nested leak is closed** — reproducing the exact failing scenario (venv pip 24.0 installing a `git+` package):

  | | cache under `$HOME` |
  |---|---|
  | `--no-cache-dir` only (today) | **1.3 MB created** |
  | plus `PIP_NO_CACHE_DIR=1` | **no cache created** |

  The install still succeeds, so this is free.
- **Cleanup line is safe** — exit 0 and idempotent as both root and non-root under `set -e`, reclaiming 55 MB → 8 KB. (An earlier revision also removed `/root/.cache/pip`; that fails `Permission denied` → exit 1 and would abort the build under `set -e`, so it was dropped. `HOME=/headless` for the whole build, so `/headless` is the only cache pip can write.)
- **Coexists with the PySide6-Addons fix on this branch** — running that reinstall under the new variable succeeds, `PySide6 6.11.1` imports, and no cache is created.
- **Layer attribution confirmed** — deleting a file from a lower layer reclaims nothing, only adding a whiteout. Base-layer packages are dated `2026-07-26 13:43`; the cache is `2026-07-27 18:35–18:38`, the same window as `install_eda.sh` (snp2le `18:36:58`, charlib `18:38:06`). The cache is created *inside* this RUN layer, so the space is genuinely reclaimed.
- `bash -n install_eda.sh` passes; the `export` precedes every pip call in the script.

Expected saving: **~55 MB**, no functional change.

## Notes

- The cache's oldest files slightly predate the venv installs, so the venvs are the clearest but possibly not the only source. `PIP_NO_CACHE_DIR` covers any nested pip regardless, and the cleanup makes the outcome unconditional.
- `--no-cache-dir` now appears both in `PIP_FLAGS` and via the environment variable. The redundancy is intentional: the flags document intent at each call site and were left untouched.
