### PR TITLE
suppress xschem embedded-script execution prompt in default xschemrc

### DIFF
--- a/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
+++ b/_build/images/iic-osic-tools/skel/headless/.xschem/xschemrc
@@ -1,2 +1,6 @@
 # Source the PDK xschemrc file
 source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
+
+# Allow execution of Tcl scripts embedded in schematics/symbols without asking
+# (required for PDK launcher symbols and tcleval() attributes to work silently)
+set xschem_execute_scripts yes


### PR DESCRIPTION
## Problem

Since the xschem update, starting `xschem` in the container shows a blocking "Allow xschem to execute scripts embedded in schematics?" alert on every launch.

<img width="513" height="282" alt="image" src="https://github.com/user-attachments/assets/5d28d34e-a2e9-44c5-a878-7d0d8f86cd93" />

Newer xschem releases added a security guard around Tcl code embedded in schematics/symbols (launcher symbols, `tcleval()` attributes, ...). The setting `xschem_execute_scripts` defaults to `ask`, and since neither the container's `~/.xschem/xschemrc` nor the PDK xschemrc sets it, the dialog pops up every time.

## Fix

Set `xschem_execute_scripts yes` in the skeleton `~/.xschem/xschemrc` (after sourcing the PDK xschemrc) so the prompt no longer appears.

`yes` is the sensible default for this container: schematics come from the bundled PDKs and the user's own designs, and the PDK symbols rely on embedded Tcl (launcher symbols, dynamic title/attribute evaluation) to work properly. Users who prefer to disable script execution can still override the variable in their own xschemrc.

## Quick Fix for `latest` Image
Add the following lines into the `foss/designs/.designinit file`:
```
# Suppress xschem's embedded-script execution prompt
if ! grep -q xschem_execute_scripts /headless/.xschem/xschemrc 2>/dev/null; then
    echo 'set xschem_execute_scripts yes' >> /headless/.xschem/xschemrc
fi
```


## Testing

- Start the container, run `xschem` → no script-execution alert, embedded scripts (e.g. launcher symbols) work as before.
