### PR TITLE
Install unifont package to support unicode symbols

### DIFF
--- a/_build/images/base/scripts/00_base_install.sh
+++ b/_build/images/base/scripts/00_base_install.sh
@@ -68,6 +68,7 @@ apt-get -y install \
 	expat \
 	flex \
 	fonts-dejavu-extra \
+	unifont \
 	g++ \
 	gawk \
 	gcc \


### PR DESCRIPTION
This adds better unicode symbol support.

For example required by the klayout-netlist-importer plugin,
with this font package in place, the unicode symbol for PCells Ⓟ and static cell Ⓢ render correctly,
as on other platforms like Windows and macOS:

<img width="2564" height="484" alt="Bildschirmfoto 2026-07-31 um 20 56 52" src="https://github.com/user-attachments/assets/03b0363f-007e-4205-acea-c49f8bd5d4fd" />


Without the package:
```bash
$> fc-list :charset=24c5
$> # no output
```

With the package it works:
```bash
$> fc-list :charset=24c5
/usr/share/fonts/opentype/unifont/unifont_jp.otf: Unifont\-JP:style=Regular
/usr/share/fonts/opentype/unifont/unifont_sample.otf: Unifont Sample:style=Regular
/usr/share/fonts/opentype/unifont/unifont.otf: Unifont:style=Regular
/usr/share/fonts/opentype/unifont/unifont_jp_sample.otf: Unifont Sample:style=Regular
```