### PR TITLE
Fix rootless Podman port 80 failure in start_vnc.sh on macOS/Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ For container experts, there is also support for other container engines and add
 
 The start scripts automatically handle the classic Podman pitfalls:
 
-- In rootless mode, they add `--userns=keep-id` (unless a `--userns` option is already given via `DOCKER_EXTRA_PARAMS`), so the host user launching the container is mapped to the same UID/GID inside the container, preventing access issues between the container and mounted directories from the host.
-- Since rootless mode cannot bind host ports below 1024, `start_vnc.sh` defaults the webserver port to `8080` instead of `80` (an explicitly set `WEBSERVER_PORT` below 1024 produces a warning).
+- In rootless mode on Linux, they add `--userns=keep-id` (unless a `--userns` option is already given via `DOCKER_EXTRA_PARAMS`), so the host user launching the container is mapped to the same UID/GID inside the container, preventing access issues between the container and mounted directories from the host. On macOS and Windows the bind mount passes through the Podman machine VM, which does the ID mapping itself, so `keep-id` is not added there.
+- Since rootless mode cannot bind host ports below 1024, `start_vnc.sh` defaults the webserver port to `8080` instead of `80` (an explicitly set `WEBSERVER_PORT` below 1024 produces a warning). This also applies on macOS and Windows, where the Podman machine VM runs rootless by default and its `rootlessport` helper enforces the same limit.
 - `start_vnc.sh` passes `--sysctl net.ipv4.ip_unprivileged_port_start=0` to Podman (rootful and rootless). Docker sets this namespaced sysctl in every container by default, Podman does not — without it, the noVNC webserver (which runs as a non-root user) cannot bind port 80 *inside* the container and the VNC mode fails.
 
 So in most cases, simply running `./start_<mode>.sh` works out of the box with Podman.

--- a/start_vnc.sh
+++ b/start_vnc.sh
@@ -38,11 +38,13 @@ if [ -z ${CONTAINER_ENGINE+z} ]; then
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Container engine auto-set to ${CONTAINER_ENGINE}."
 fi
 
-# Detect Podman, and Podman rootless mode on Linux (the docker CLI can also
-# be the podman-docker alias, so check the version string).
+# Detect Podman, and Podman rootless mode (the docker CLI can also be the
+# podman-docker alias, so check the version string). On macOS and Windows the
+# Podman machine VM is rootless by default as well, and its rootlessport
+# helper has the same restriction on publishing privileged ports.
 if ${CONTAINER_ENGINE} --version 2>/dev/null | grep -qi "podman"; then
 	ENGINE_IS_PODMAN=1
-	if [[ "$OSTYPE" == "linux"* ]] && ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
+	if ${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi "true"; then
 		ENGINE_IS_ROOTLESS=1
 		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Podman rootless mode detected."
 	fi
@@ -137,9 +139,11 @@ if [[ ${CONTAINER_GROUP} -ne 0 ]]  && [[ ${CONTAINER_GROUP} -lt 1000 ]]; then
         echo
 fi
 
-# In Podman rootless mode, keep the host UID/GID inside the container so
-# bind-mounted files keep their ownership (see README section 5.1).
-if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "${CONTAINER_USER}" != "0" ]; then
+# In Podman rootless mode on Linux, keep the host UID/GID inside the container
+# so bind-mounted files keep their ownership (see README section 5.1). On
+# macOS/Windows the mount goes through the Podman machine VM, which handles the
+# ID mapping itself, so keep-id is not applied there.
+if [ -n "${ENGINE_IS_ROOTLESS}" ] && [[ "$OSTYPE" == "linux"* ]] && [ "${CONTAINER_USER}" != "0" ]; then
 	if ! echo "${DOCKER_EXTRA_PARAMS}" | grep -q "userns"; then
 		[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && echo "[INFO] Adding --userns=keep-id for Podman rootless mode."
 		DOCKER_EXTRA_PARAMS="${DOCKER_EXTRA_PARAMS} --userns=keep-id"
@@ -217,6 +221,13 @@ else
 	#${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" pull "${IMAGE_NAME}"
 	# Disable SC2086, $PARAMS must be globbed and splitted.
 	# shellcheck disable=SC2086
-	${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${IMAGE_NAME}" > /dev/null
+	if ! ${ECHO_IF_DRY_RUN} "${CONTAINER_ENGINE}" run -d --user "${CONTAINER_USER}:${CONTAINER_GROUP}" $PARAMS -v "$DESIGNS":"/foss/designs":rw --name "${CONTAINER_NAME}" "${IMAGE_NAME}" > /dev/null; then
+		echo "[ERROR] Could not start the container ${CONTAINER_NAME}!"
+		echo "[HINT] A leftover container can be removed with \"${CONTAINER_ENGINE} rm ${CONTAINER_NAME}\"."
+		if [ -n "${ENGINE_IS_ROOTLESS}" ] && [ "$WEBSERVER_PORT" -gt 0 ] && [ "$WEBSERVER_PORT" -lt 1024 ]; then
+			echo "[HINT] Rootless Podman cannot publish host ports below 1024, retry with e.g. WEBSERVER_PORT=8080."
+		fi
+		exit 1
+	fi
 	[ -z "${IIC_OSIC_TOOLS_QUIET}" ] && [ "$WEBSERVER_PORT" -gt 0 ] && echo "[INFO] To access the VNC session, open a browser and navigate to http://localhost:${WEBSERVER_PORT}/?password=${VNC_PW:-abc123}"
 fi


### PR DESCRIPTION
## Problem

On macOS, `./start_vnc.sh` fails to create the container:

```
Error: rootlessport cannot expose privileged port 80, you can add
'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024),
or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied
[INFO] To access the VNC session, open a browser and navigate to http://localhost:80/?password=abc123
```

The script already handles this, but the rootless detection was gated on `[[ "$OSTYPE" == "linux"* ]]`. The Podman machine VM on macOS/Windows is rootless by default as well (`podman info` reports `Rootless: true`) and its `rootlessport` helper enforces the same "no host ports below 1024" rule, so `WEBSERVER_PORT` stayed at `80` and container creation failed.

Note the misleading last line: the container had failed, but the success URL was printed anyway.

## Changes

- Drop the OS gate on the rootless detection, so the webserver port auto-selects `8080` on macOS/Windows too.
- Keep `--userns=keep-id` Linux-only. On macOS/Windows the bind mount passes through the machine VM, which does the ID mapping itself, so this is deliberately not a behavior change for those hosts.
- Check the exit status of the container run. A failure now reports an error plus hints (how to remove the leftover container, and the privileged-port hint when applicable) and exits non-zero instead of printing a success URL.
- Update the Podman section of the README accordingly.

A failed run leaves the container in `Created` state with the bad port mapping baked in — port mappings are fixed at create time, so it must be removed rather than restarted. That is what the new hint points at.

## Testing

On macOS (Podman 6.0.2, rootless machine VM):

- `shellcheck start_vnc.sh` clean, `bash -n` clean.
- `DRY_RUN=1 ./start_vnc.sh` reports rootless mode, port 8080, and no `--userns=keep-id`.
- Real run: container `Up`, `0.0.0.0:8080->80/tcp`, `curl http://localhost:8080/` returns HTTP 200.
- Failure path checked with an explicit `WEBSERVER_PORT=80`: warning, error, both hints, exit code 1, and no success URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)