### PR TITLE
point tests 20, 22, and 28 at the `next_release` branch

### DIFF
--- a/_tests/20/test_ams_chip_sg13g2.sh
+++ b/_tests/20/test_ams_chip_sg13g2.sh
@@ -20,9 +20,9 @@ REPO=ihp-sg13g2-ams-chip-template
 mkdir -p "$TMP"
 cd "$TMP" || exit 1
 
-# Clone the main branch of the AMS chip template (incl. submodules)
-[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (main branch, incl. submodules) ..."
-if ! git clone --depth 1 --recursive --shallow-submodules --branch main \
+# Clone the next_release branch of the AMS chip template (incl. submodules)
+[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (next_release branch, incl. submodules) ..."
+if ! git clone --depth 1 --recursive --shallow-submodules --branch next_release \
         https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
     echo "[ERROR] Test <AMS chip template with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
     exit 1

--- a/_tests/22/test_sparx_sg13g2.sh
+++ b/_tests/22/test_sparx_sg13g2.sh
@@ -27,9 +27,9 @@ REPO=SG13CMOS_SPARX
 mkdir -p "$TMP"
 cd "$TMP" || exit 1
 
-# Clone the main branch of the SPARX repository
-[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (main branch) ..."
-if ! git clone --depth 1 --branch main \
+# Clone the next_release branch of the SPARX repository
+[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (next_release branch) ..."
+if ! git clone --depth 1 --branch next_release \
         https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
     echo "[ERROR] Test <SPARX with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
     exit 1

--- a/_tests/28/test_tinywhisper_sg13g2.sh
+++ b/_tests/28/test_tinywhisper_sg13g2.sh
@@ -27,9 +27,9 @@ REPO=TinyWhisper
 mkdir -p "$TMP"
 cd "$TMP" || exit 1
 
-# Clone the main branch of the TinyWhisper repository (incl. submodules)
-[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (main branch, incl. submodules) ..."
-if ! git clone --depth 1 --recursive --shallow-submodules --branch main \
+# Clone the next_release branch of the TinyWhisper repository (incl. submodules)
+[ "$DEBUG" = 1 ] && echo "[INFO] Cloning $REPO (next_release branch, incl. submodules) ..."
+if ! git clone --depth 1 --recursive --shallow-submodules --branch next_release \
         https://github.com/iic-jku/"$REPO".git "$REPO" > "$LOG" 2>&1; then
     echo "[ERROR] Test <TinyWhisper with ihp-sg13g2> FAILED! Could not clone the repository. Check the log file $LOG for details."
     exit 1


### PR DESCRIPTION
The AMS chip template, SPARX, and TinyWhisper repositories now carry the matching design updates on their `next_release` branches, so tests 20, 22, and 28 clone `next_release` instead of main.

Also updates the comments and the [INFO] Cloning messages in the three scripts to name the new branch.
